### PR TITLE
ci: add npm auto-publish workflow + bump to v0.1.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,42 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - name: Bump patch version if already published
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "cc-skill-trace@${VERSION}" version 2>/dev/null | grep -qF "${VERSION}"; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            npm version patch -m "chore: bump version to %s [skip ci]"
+            git push
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-skill-trace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Skill invocation debugger and visualizer for Claude Code — see which skills fired, when, and why",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
Adds .github/workflows/npm-publish.yml that triggers on every push to
main. If the current package.json version is already on npm, it bumps
the patch version and commits back with [skip ci] before publishing.

Requires NPM_TOKEN secret in repository settings.

https://claude.ai/code/session_01Y1HebFgGsQAzGrQVQewPhu