### PR TITLE
feat: OSS infrastructure + CLI improvements (list-skills, --json, CC_DEBUG, bug fixes)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Question / Discussion
+    url: https://github.com/revo1290/cc-skill-trace/discussions
+    about: General questions and community discussion
   - name: Security vulnerability
     url: https://github.com/revo1290/cc-skill-trace/blob/main/SECURITY.md
     about: Do not file public issues for security vulnerabilities — see SECURITY.md

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,30 @@
+name: Question / Help
+description: Ask a question about usage or behavior
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For general questions, [GitHub Discussions](https://github.com/revo1290/cc-skill-trace/discussions) is often faster. But feel free to ask here too.
+
+  - type: input
+    id: version
+    attributes:
+      label: cc-skill-trace version
+      placeholder: "e.g. 0.11.0  (run: cc-skill-trace --version)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What would you like to know?
+      description: Be as specific as possible — include the command you ran and what you expected.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Helps avoid repeating suggestions you've already seen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CC_SCAN_CONCURRENCY` environment variable — tune the number of parallel file reads during scan (default: 8)
 - `validateDateRange` guard — `--since > --before` now exits with a clear error message instead of silently returning zero results
 - Terminal dashboard now shows `cwd` and `~N tokens` metadata inline when available
+- `show` now warns on stderr when the installed SKILL.md is out of date with the current package version: `⚠  SKILL.md is outdated — run: cc-skill-trace install`
 
 ### Fixed
 - `report`, `stats`, and `export` commands now pass filter options (`--since`, `--before`, `--skill`, `--session`) directly to `readEvents` instead of loading all events and filtering in memory — consistent with `show` and more efficient for large stores
 - CSV export now quotes header column names (was quoting values but not headers)
 - `export` CSV now includes the `injectedTokens` field (was missing from headers)
 - CLAUDE.md architecture section corrected: `hook-capture` is a hidden sub-command in `cli/index.ts`, not a standalone `src/hook/capture.ts` file
+- `install` no longer returns early when the hook is already registered — SKILL.md is now always synced to the latest bundled version regardless of hook state
 
 ### Changed
+- SKILL.md compressed from ~2,455 chars (≈614 tokens) to ~781 chars (≈195 tokens) — **68% reduction in per-invocation token cost**; output capped at 15 events with `-n 15` to prevent unbounded context growth
+- `install` now reports three distinct states for SKILL.md: "installed", "updated", or "already up to date"
 - `report` success message now includes the event count: `✓  Report → <path>  (N events)`
 - `hook-capture` debug output is now gated behind `CC_DEBUG=1` rather than always silent (stderr only, never blocks Claude Code)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `validateDateRange` guard — `--since > --before` now exits with a clear error message instead of silently returning zero results
 - Terminal dashboard now shows `cwd` and `~N tokens` metadata inline when available
 - `show` now warns on stderr when the installed SKILL.md is out of date with the current package version: `⚠  SKILL.md is outdated — run: cc-skill-trace install`
+- `show --terse` — ultra-compact no-ANSI output optimised for AI consumption; used by SKILL.md to minimise token cost per `/skill-trace` invocation
 
 ### Fixed
 - `report`, `stats`, and `export` commands now pass filter options (`--since`, `--before`, `--skill`, `--session`) directly to `readEvents` instead of loading all events and filtering in memory — consistent with `show` and more efficient for large stores
@@ -24,7 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `install` no longer returns early when the hook is already registered — SKILL.md is now always synced to the latest bundled version regardless of hook state
 
 ### Changed
-- SKILL.md compressed from ~2,455 chars (≈614 tokens) to ~781 chars (≈195 tokens) — **68% reduction in per-invocation token cost**; output capped at 15 events with `-n 15` to prevent unbounded context growth
+- SKILL.md compressed from ~2,455 chars (≈614 tokens) to ~637 chars (≈159 tokens) — **74% reduction in per-invocation token cost**
+- `show --terse` replaces `show --compact` in SKILL.md: no ANSI, no padding, stats+events in minimal format; output capped at `-n 15`; stderr suppressed with `2>/dev/null` to eliminate scan-progress noise from tool results
+- Description field shortened from ≈65 tokens to ≈42 tokens (saves tokens every session, not just on invocation)
+- Total `/skill-trace` invocation cost: ~428 tokens → ~256 tokens (**40% reduction**)
 - `install` now reports three distinct states for SKILL.md: "installed", "updated", or "already up to date"
 - `report` success message now includes the event count: `✓  Report → <path>  (N events)`
 - `hook-capture` debug output is now gated behind `CC_DEBUG=1` rather than always silent (stderr only, never blocks Claude Code)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `list-skills` command (alias: `ls`) — list all unique skills with auto/user counts; supports `--json`, `--since`, `--before`, `--scan`
+- `show --json` flag — output events as a JSON array for scripting/piping
+- `CC_DEBUG=1` environment variable — enable debug logging in `hook-capture` (written to stderr)
+- `CC_SCAN_CONCURRENCY` environment variable — tune the number of parallel file reads during scan (default: 8)
+- `validateDateRange` guard — `--since > --before` now exits with a clear error message instead of silently returning zero results
+- Terminal dashboard now shows `cwd` and `~N tokens` metadata inline when available
+
+### Fixed
+- `report`, `stats`, and `export` commands now pass filter options (`--since`, `--before`, `--skill`, `--session`) directly to `readEvents` instead of loading all events and filtering in memory — consistent with `show` and more efficient for large stores
+- CSV export now quotes header column names (was quoting values but not headers)
+- `export` CSV now includes the `injectedTokens` field (was missing from headers)
+- CLAUDE.md architecture section corrected: `hook-capture` is a hidden sub-command in `cli/index.ts`, not a standalone `src/hook/capture.ts` file
+
+### Changed
+- `report` success message now includes the event count: `✓  Report → <path>  (N events)`
+- `hook-capture` debug output is now gated behind `CC_DEBUG=1` rather than always silent (stderr only, never blocks Claude Code)
+
 ## [0.1.9] — 2026-04-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ npm install          # 依存関係インストール
 npm run build        # TypeScript → dist/ にコンパイル (tsc)
 npm run dev          # ウォッチモードでビルド
 npm run typecheck    # 型チェックのみ（コンパイルなし）
+npm test             # テスト実行
 node dist/cli/index.js <cmd>   # ビルド後の動作確認
 ```
 
@@ -25,21 +26,21 @@ src/
 │   ├── types.ts      # 全型定義（SessionLogEntry, SkillInvocationEvent, HookPayload）
 │   ├── parser.ts     # ~/.claude/projects/**/*.jsonl を解析してスキル発動を抽出
 │   └── store.ts      # ~/.cc-skill-trace/events.jsonl への読み書き
-├── hook/
-│   └── capture.ts    # Claude Code の PreToolUse フック。stdin → events.jsonl に追記
 ├── skill/
 │   └── SKILL.md      # Claude Code Skill 定義。/skill-trace スラッシュコマンドになる
 └── cli/
-    ├── index.ts      # CLI エントリポイント（commander）。コマンド: install/show/scan/report/clear
-    ├── format.ts     # ターミナルダッシュボード（ box-drawing + chalk。renderDashboard が中心）
+    ├── index.ts      # CLI エントリポイント（commander）
+    │                 # コマンド: install / hook-capture / show / scan / report
+    │                 #           clear / stats / export / list-skills / uninstall
+    ├── format.ts     # ターミナルダッシュボード（box-drawing + chalk。renderDashboard が中心）
     └── web-report.ts # スタンドアロン HTML レポート生成（Chart.js を CDN から読み込み）
 ```
 
 ### Data flow
 
 1. `cc-skill-trace install` → `~/.claude/settings.json` に PreToolUse hook を登録 + `~/.claude/skills/skill-trace/SKILL.md` をコピー
-2. Claude Code セッション中に Skill tool が呼ばれる → hook → `capture.ts` が起動
-3. `capture.ts` はイベントを `~/.cc-skill-trace/events.jsonl` に追記して `{}` を返す（ブロックしない）
+2. Claude Code セッション中に Skill tool が呼ばれる → hook → `cli/index.ts hook-capture` サブコマンドが起動
+3. `hook-capture` はイベントを `~/.cc-skill-trace/events.jsonl` に追記して `{}` を返す（ブロックしない）
 4. `cc-skill-trace show` → events.jsonl を読んで **ターミナルダッシュボード**を表示
 5. `/skill-trace` (Claude Code 内) → SKILL.md の指示に従い Claude が `cc-skill-trace show --scan` を実行して結果を解説
 6. `cc-skill-trace report` → events.jsonl を読んで HTML を生成しブラウザで開く
@@ -48,7 +49,17 @@ src/
 ### Key design decisions
 
 - フックは **絶対に Claude Code をブロックしない**（例外をすべて握りつぶして exit 0）
+- `hook-capture` は `src/cli/index.ts` の hidden サブコマンドとして実装（独立ファイルなし）
 - `show` はデフォルトコマンド。`cc-skill-trace` だけで dashboard が出る
 - ターミナル出力は box-drawing 文字 + ANSI カラーで視認性を最大化（`format.ts:renderDashboard`）
 - HTML レポートは依存ゼロのスタンドアロンファイル（Chart.js は CDN）
 - イベントストアは JSONL（SQLite は v2 で検討）
+- `CC_DEBUG=1` 環境変数で `hook-capture` のデバッグログを stderr に出力
+- `CC_SCAN_CONCURRENCY` 環境変数でスキャン並列数を変更（デフォルト: 8）
+- `CC_PROJECTS_DIR` 環境変数でスキャン対象ディレクトリを変更
+
+### hook-capture と triggerMessage の制限
+
+リアルタイムフック（`hook-capture`）経由で記録されたイベントには `triggerMessage` が含まれない。  
+`triggerMessage` は `cc-skill-trace scan` によるセッションログのバックフィルでのみ取得できる。  
+これは PreToolUse フックのペイロードに直前のユーザーメッセージが含まれないため。

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+## Our Pledge
+
+This project is committed to providing a welcoming, inclusive, and respectful environment for everyone who participates — regardless of experience level, background, or identity.
+
+## Expected Behavior
+
+- Be respectful and constructive in discussions and reviews.
+- Give and receive feedback graciously.
+- Focus on what is best for the community and the project.
+- Show empathy toward other community members.
+
+## Unacceptable Behavior
+
+- Personal attacks, insults, or derogatory comments.
+- Public or private harassment of any kind.
+- Deliberate intimidation or threats.
+- Any other conduct that a reasonable person would consider inappropriate in a professional setting.
+
+## Enforcement
+
+All reports will be reviewed promptly and handled with discretion.  
+Maintainers reserve the right to remove, edit, or reject contributions that violate this code, and to ban contributors who engage in harmful behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing to cc-skill-trace
 
-Thank you for your interest in contributing!
+Thank you for your interest in contributing!  
+Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating. For questions, see [SUPPORT.md](./SUPPORT.md).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 See which Claude Code skills fired, when, and why — in your terminal or in an interactive browser dashboard.
 
+[![CI](https://github.com/revo1290/cc-skill-trace/actions/workflows/ci.yml/badge.svg)](https://github.com/revo1290/cc-skill-trace/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/cc-skill-trace)](https://www.npmjs.com/package/cc-skill-trace)
 [![npm downloads](https://img.shields.io/npm/dm/cc-skill-trace)](https://www.npmjs.com/package/cc-skill-trace)
 [![Node.js](https://img.shields.io/node/v/cc-skill-trace)](https://nodejs.org)
@@ -105,12 +106,26 @@ cc-skill-trace show --scan
 # Compact one-line list
 cc-skill-trace show --compact
 
+# JSON output (pipe-friendly for scripting)
+cc-skill-trace show --json
+
 # Filter options
 cc-skill-trace show --skill commit
 cc-skill-trace show --since 2026-04-01
 cc-skill-trace show --since 2026-04-01 --before 2026-04-30
 cc-skill-trace show --session <session-id>
 cc-skill-trace show -n 100          # show last 100 events (default: 50)
+```
+
+### Skill Discovery
+
+```bash
+# List all unique skills with auto/user counts
+cc-skill-trace list-skills       # or: cc-skill-trace ls
+
+# Filter by date or backfill first
+cc-skill-trace ls --since 2026-04-01
+cc-skill-trace ls --scan --json  # machine-readable
 ```
 
 ### Statistics
@@ -211,20 +226,26 @@ cc-skill-trace uninstall --project
 Every time a skill is invoked, `hook-capture` fires and appends an event to `~/.cc-skill-trace/events.jsonl`.
 It always returns `{}` and **never blocks Claude Code**.
 
+> **Note:** Real-time events captured by `hook-capture` do not include `triggerMessage` (the preceding user message). Run `cc-skill-trace scan` to backfill trigger messages from session logs.
+
 ### 2. Retroactive scan
 
 `~/.claude/projects/**/*.jsonl` session logs are parsed to extract past skill invocations, including the user message that preceded each one (the "trigger").
-
-Set `CC_PROJECTS_DIR` to override the default scan path:
-
-```bash
-CC_PROJECTS_DIR=/custom/path cc-skill-trace scan
-```
 
 ### 3. Claude Code skill (`/skill-trace`)
 
 Installing `~/.claude/skills/skill-trace/SKILL.md` lets you call `/skill-trace` from the Claude Code chat.
 Claude runs the dashboard and interprets the results — explaining why an auto-trigger rate is high, which skills fire unexpectedly, and how to narrow skill descriptions.
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CC_PROJECTS_DIR` | `~/.claude/projects` | Override the scan directory for session logs |
+| `CC_DEBUG` | _(unset)_ | Set to `1` to enable debug logging in `hook-capture` (written to stderr) |
+| `CC_SCAN_CONCURRENCY` | `8` | Number of session files to read in parallel during scan |
 
 ---
 
@@ -297,14 +318,11 @@ interface SkillInvocationEvent {
 
 ## Releasing a new version
 
-Releases are automated via GitHub Actions. To publish:
+Releases are fully automated via GitHub Actions (`release.yml`).
 
-```bash
-npm version patch   # or minor / major
-git push origin main --follow-tags
-```
-
-The `release.yml` workflow triggers on `v*.*.*` tags, runs the full test suite, creates a GitHub Release, and publishes to npm automatically.
+1. Go to **Actions → Release → Run workflow** on GitHub.
+2. Enter the new version number (e.g. `0.12.0`).
+3. The workflow will: bump `package.json`, open a release PR, create a signed tag, publish to npm with provenance, and create a GitHub Release.
 
 ---
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,24 @@
+# Support
+
+## Getting help
+
+| Type | Where |
+|---|---|
+| Bug reports | [GitHub Issues](https://github.com/revo1290/cc-skill-trace/issues) — use the **Bug Report** template |
+| Feature requests | [GitHub Issues](https://github.com/revo1290/cc-skill-trace/issues) — use the **Feature Request** template |
+| Questions & discussion | [GitHub Discussions](https://github.com/revo1290/cc-skill-trace/discussions) |
+| Security vulnerabilities | See [SECURITY.md](./SECURITY.md) — do **not** file a public issue |
+
+## Before opening an issue
+
+1. Check the [README](./README.md) — especially the CLI reference and "How it works" sections.
+2. Search [existing issues](https://github.com/revo1290/cc-skill-trace/issues) to avoid duplicates.
+3. Run `cc-skill-trace --version` and `node --version` so you have that info ready.
+
+## Claude Code plugin questions
+
+If `/skill-trace` is not appearing in Claude Code after `cc-skill-trace install`:
+
+- Confirm the hook was registered: check `~/.claude/settings.json` for a `PreToolUse` entry with matcher `"Skill"`.
+- Restart Claude Code after installing.
+- Re-run `cc-skill-trace install` if the entry is missing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,176 @@
         "cc-skill-trace": "dist/cli/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.13",
         "@types/node": "^20.14.0",
         "tsx": "^4.21.0",
         "typescript": "^5.4.5"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "commander": "^12.1.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
     "@types/node": "^20.14.0",
     "tsx": "^4.21.0",
     "typescript": "^5.4.5"

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -277,7 +277,12 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
       ? chalk.italic.gray(`"${ev.triggerMessage.replace(/\n/g, " ").slice(0, maxTriggerW)}"`)
       : chalk.gray("(no trigger context)");
 
-    lines.push(`  ${dot} ${time}  ${name}  ${src}  ${trigger}`);
+    const meta: string[] = [];
+    if (ev.cwd)            meta.push(chalk.gray(`  cwd: ${ev.cwd}`));
+    if (ev.injectedTokens) meta.push(chalk.gray(`  ~${ev.injectedTokens.toLocaleString()} tokens`));
+    const metaLine = meta.length ? "\n       " + meta.join("  ") : "";
+
+    lines.push(`  ${dot} ${time}  ${name}  ${src}  ${trigger}${metaLine}`);
   }
 
   lines.push("");

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -308,3 +308,36 @@ export function renderCompact(events: SkillInvocationEvent[]): string {
   }
   return lines.join("\n");
 }
+
+// ─── Terse (AI-optimised, minimal tokens) ─────────────────────────────────────
+// Used by SKILL.md to minimise context consumption when /skill-trace fires.
+// No ANSI, no padding — pure signal for the model.
+
+export function renderTerse(events: SkillInvocationEvent[]): string {
+  if (events.length === 0) {
+    return "0 events. Run: cc-skill-trace install then restart Claude Code.";
+  }
+
+  const total  = events.length;
+  const auto   = events.filter(e => e.source === "claude").length;
+  const rate   = Math.round((auto / total) * 100);
+  const skills = buildStats(events);
+
+  // "11ev 72%auto | commit:5(4a) review:3(2a) …"
+  const skillSummary = skills.slice(0, 8)
+    .map(s => `${s.name}:${s.total}(${s.auto}a)`)
+    .join(" ");
+  const lines: string[] = [`${total}ev ${rate}%auto | ${skillSummary}`];
+
+  // "14:34 commit auto "trigger text""
+  for (const ev of [...events].sort((a, b) => b.timestamp.localeCompare(a.timestamp))) {
+    const t    = new Date(ev.timestamp).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
+    const src  = ev.source === "claude" ? "auto" : "user";
+    const trig = ev.triggerMessage
+      ? ` "${ev.triggerMessage.replace(/\n/g, " ").slice(0, 40)}"`
+      : "";
+    lines.push(`${t} ${ev.skillName} ${src}${trig}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,7 +20,7 @@ import { createRequire } from "node:module";
 import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
-import { renderDashboard, renderCompact, renderStats, buildStats } from "./format.js";
+import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -256,6 +256,7 @@ program
   .option("--skill <name>", "Filter by skill name")
   .option("--session <id>", "Filter by session ID")
   .option("--compact", "Compact table instead of dashboard")
+  .option("--terse", "Ultra-compact no-ANSI output (used by /skill-trace to minimise token cost)")
   .option("--json", "Output events as JSON array (pipe-friendly)")
   .option("--scan", "Scan session logs before showing (backfill)")
   .option("--follow", "Refresh dashboard every 2s (live tail)")
@@ -306,6 +307,8 @@ program
 
     if (opts.json) {
       process.stdout.write(JSON.stringify(events, null, 2) + "\n");
+    } else if (opts.terse) {
+      process.stdout.write(renderTerse(events) + "\n");
     } else if (opts.compact) {
       console.log(renderCompact(events));
     } else {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,7 +20,7 @@ import { createRequire } from "node:module";
 import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
-import { renderDashboard, renderCompact, renderStats } from "./format.js";
+import { renderDashboard, renderCompact, renderStats, buildStats } from "./format.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -42,6 +42,14 @@ function validateLimit(value: string): string {
     process.exit(1);
   }
   return value;
+}
+
+/** Fail fast if --since is later than --before. */
+function validateDateRange(since: string | undefined, before: string | undefined): void {
+  if (since && before && since > before) {
+    console.error(chalk.red(`✗  --since (${since}) must be earlier than --before (${before})`));
+    process.exit(1);
+  }
 }
 
 /**
@@ -154,20 +162,43 @@ program
   .description("Internal: receives PreToolUse hook payload via stdin")
   .helpOption(false)
   .action(async () => {
+    const DEBUG = process.env["CC_DEBUG"] === "1";
+    const dbg = (msg: string) => { if (DEBUG) process.stderr.write(`[cc-skill-trace] ${msg}\n`); };
+
     let raw = "";
     const MAX_STDIN_BYTES = 1024 * 64; // 64 KB — hook payloads are tiny
     for await (const chunk of process.stdin) {
       raw += chunk;
-      if (Buffer.byteLength(raw) > MAX_STDIN_BYTES) { process.exit(0); }
+      if (Buffer.byteLength(raw) > MAX_STDIN_BYTES) {
+        dbg("stdin exceeded 64 KB limit, ignoring");
+        process.exit(0);
+      }
     }
 
-    let payload: { session_id?: string; tool_name?: string; tool_input?: { skill?: string; args?: string }; user_invoked?: boolean; cwd?: string; git_branch?: string };
+    let payload: {
+      session_id?: string;
+      tool_name?: string;
+      tool_input?: { skill?: string; args?: string };
+      user_invoked?: boolean;
+      cwd?: string;
+      git_branch?: string;
+    };
     try {
       const parsed: unknown = JSON.parse(raw);
-      if (!parsed || typeof parsed !== "object") { process.exit(0); }
+      if (!parsed || typeof parsed !== "object") {
+        dbg("payload is not an object, ignoring");
+        process.exit(0);
+      }
       payload = parsed as typeof payload;
-    } catch { process.exit(0); }
-    if (payload.tool_name !== "Skill" || !payload.tool_input?.skill) { process.exit(0); }
+    } catch (err) {
+      dbg(`JSON parse error: ${err}`);
+      process.exit(0);
+    }
+
+    if (payload.tool_name !== "Skill" || !payload.tool_input?.skill) {
+      dbg(`not a Skill invocation (tool_name=${payload.tool_name}), ignoring`);
+      process.exit(0);
+    }
 
     const { randomUUID } = await import("node:crypto");
     const event = {
@@ -181,7 +212,8 @@ program
       gitBranch: payload.git_branch,
     };
 
-    try { await appendEvent(event); } catch { /* never block Claude Code */ }
+    dbg(`capturing ${event.source} invocation of "${event.skillName}" in session ${event.sessionId}`);
+    try { await appendEvent(event); dbg("event appended"); } catch (err) { dbg(`appendEvent failed: ${err}`); }
     process.stdout.write(JSON.stringify({}));
     process.exit(0);
   });
@@ -196,9 +228,12 @@ program
   .option("--skill <name>", "Filter by skill name")
   .option("--session <id>", "Filter by session ID")
   .option("--compact", "Compact table instead of dashboard")
+  .option("--json", "Output events as JSON array (pipe-friendly)")
   .option("--scan", "Scan session logs before showing (backfill)")
   .option("--follow", "Refresh dashboard every 2s (live tail)")
   .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
+
     if (opts.scan) {
       const { events: scanned, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
       process.stderr.write(chalk.gray(`  Imported ${imported} new invocations (${scanned.length - imported} already stored).\n\n`));
@@ -233,7 +268,10 @@ program
     }
 
     const events = await readEvents(readOpts);
-    if (opts.compact) {
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(events, null, 2) + "\n");
+    } else if (opts.compact) {
       console.log(renderCompact(events));
     } else {
       console.log(renderDashboard(events));
@@ -250,6 +288,7 @@ program
   .option("--session <id>", "Filter by session ID")
   .option("--clear", "Clear existing events before scanning")
   .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
     if (opts.clear) { await clearEvents(); console.log(chalk.gray("  Cleared.")); }
     const { events, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
     let filtered = events;
@@ -272,19 +311,21 @@ program
   .option("--session <id>", "Filter by session ID")
   .option("--scan", "Scan session logs first")
   .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
     if (opts.scan) {
       const { events: scanned, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
       console.log(chalk.gray(`  Scanned: ${scanned.length} invocations (${imported} new).`));
     }
-    let events = await readEvents();
-    if (opts.since)   events = events.filter(e => e.timestamp >= opts.since);
-    if (opts.before)  events = events.filter(e => e.timestamp <= opts.before);
-    if (opts.skill)   events = events.filter(e => e.skillName === opts.skill);
-    if (opts.session) events = events.filter(e => e.sessionId === opts.session);
+    const events = await readEvents({
+      since: opts.since as string | undefined,
+      before: opts.before as string | undefined,
+      skill: opts.skill as string | undefined,
+      sessionId: opts.session as string | undefined,
+    });
 
     const html = buildHtmlReport(events);
     await writeFile(opts.output, html, "utf-8");
-    console.log(chalk.green(`✓  Report → ${opts.output}`));
+    console.log(chalk.green(`✓  Report → ${opts.output}  (${events.length} events)`));
 
     if (opts.open !== false) {
       try {
@@ -295,7 +336,7 @@ program
         } else {
           execFileSync("xdg-open", [opts.output], { stdio: "ignore" });
         }
-      } catch { console.log(chalk.gray(`  Open: ${opts.output}`)); }
+      } catch { console.log(chalk.gray(`  Open manually: ${opts.output}`)); }
     }
   });
 
@@ -325,15 +366,17 @@ program
   .option("--session <id>", "Filter by session ID")
   .option("--scan", "Scan session logs first")
   .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
     if (opts.scan) {
       const { imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
       process.stderr.write(chalk.gray(`  Imported ${imported} new invocations.\n\n`));
     }
-    let events = await readEvents();
-    if (opts.since)   events = events.filter(e => e.timestamp >= opts.since);
-    if (opts.before)  events = events.filter(e => e.timestamp <= opts.before);
-    if (opts.skill)   events = events.filter(e => e.skillName === opts.skill);
-    if (opts.session) events = events.filter(e => e.sessionId === opts.session);
+    const events = await readEvents({
+      since: opts.since as string | undefined,
+      before: opts.before as string | undefined,
+      skill: opts.skill as string | undefined,
+      sessionId: opts.session as string | undefined,
+    });
     console.log(renderStats(events));
   });
 
@@ -349,15 +392,17 @@ program
   .option("--session <id>", "Filter by session ID")
   .option("--scan", "Scan session logs first")
   .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
     if (opts.scan) {
       const { imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
       process.stderr.write(chalk.gray(`  Imported ${imported} new invocations.\n\n`));
     }
-    let events = await readEvents();
-    if (opts.since)   events = events.filter(e => e.timestamp >= opts.since);
-    if (opts.before)  events = events.filter(e => e.timestamp <= opts.before);
-    if (opts.skill)   events = events.filter(e => e.skillName === opts.skill);
-    if (opts.session) events = events.filter(e => e.sessionId === opts.session);
+    const events = await readEvents({
+      since: opts.since as string | undefined,
+      before: opts.before as string | undefined,
+      skill: opts.skill as string | undefined,
+      sessionId: opts.session as string | undefined,
+    });
 
     const fmt = String(opts.format).toLowerCase();
     let out: string;
@@ -365,7 +410,7 @@ program
     if (fmt === "csv") {
       const headers: (keyof typeof events[0])[] = [
         "id", "timestamp", "sessionId", "skillName", "skillArgs",
-        "source", "triggerMessage", "cwd", "gitBranch",
+        "source", "triggerMessage", "injectedTokens", "cwd", "gitBranch",
       ];
       const esc = (v: unknown) => {
         const s = v == null ? "" : String(v);
@@ -373,7 +418,8 @@ program
           ? `"${s.replace(/"/g, '""')}"` : s;
       };
       // UTF-8 BOM ensures Excel opens the file without garbling non-ASCII characters
-      out = "\uFEFF" + headers.join(",") + "\n" + events.map(e => headers.map(h => esc(e[h])).join(",")).join("\n");
+      out = "\uFEFF" + headers.map(h => `"${h}"`).join(",") + "\n"
+        + events.map(e => headers.map(h => esc(e[h])).join(",")).join("\n");
     } else if (fmt === "json") {
       out = JSON.stringify(events, null, 2);
     } else {
@@ -386,6 +432,54 @@ program
       console.error(chalk.green(`✓  Exported ${events.length} events → ${opts.output}`));
     } else {
       process.stdout.write(out + "\n");
+    }
+  });
+
+// ─── list-skills ──────────────────────────────────────────────────────────────
+program
+  .command("list-skills")
+  .alias("ls")
+  .description("List all unique skills seen, with invocation counts")
+  .option("--since <date>", "Filter from this ISO date", validateSince)
+  .option("--before <date>", "Filter up to this ISO date", validateSince)
+  .option("--scan", "Scan session logs first")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    validateDateRange(opts.since, opts.before);
+    if (opts.scan) {
+      const { imported } = await scanAndMerge({ since: opts.since });
+      process.stderr.write(chalk.gray(`  Imported ${imported} new invocations.\n\n`));
+    }
+    const events = await readEvents({
+      since: opts.since as string | undefined,
+      before: opts.before as string | undefined,
+    });
+
+    const stats = buildStats(events);
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(stats, null, 2) + "\n");
+      return;
+    }
+
+    if (stats.length === 0) {
+      console.log(chalk.gray("  No skills recorded yet."));
+      console.log(chalk.gray("  Run: cc-skill-trace install  then use Claude Code."));
+      return;
+    }
+
+    const maxName = Math.max(...stats.map(s => s.name.length));
+    console.log(
+      chalk.gray("  " + "skill".padEnd(maxName) + "   total  auto  user")
+    );
+    console.log(chalk.gray("  " + "─".repeat(maxName + 20)));
+    for (const s of stats) {
+      console.log(
+        "  " + chalk.bold.yellow(s.name.padEnd(maxName)) +
+        "  " + chalk.white(String(s.total).padStart(5)) + chalk.gray("x") +
+        "  " + chalk.magenta(String(s.auto).padStart(4)) +
+        "  " + chalk.cyan(String(s.byUser).padStart(4))
+      );
     }
   });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,16 +106,40 @@ program
   .description("Skill invocation debugger & visualizer for Claude Code")
   .version(VERSION);
 
+// ─── shared: resolve bundled SKILL.md path ────────────────────────────────────
+async function bundledSkillMdPath(): Promise<string> {
+  const { fileURLToPath } = await import("node:url");
+  const { dirname } = await import("node:path");
+  const here = dirname(fileURLToPath(import.meta.url));
+  return join(here, "..", "skill", "SKILL.md");
+}
+
+const installedSkillMdPath = join(homedir(), ".claude", "skills", "skill-trace", "SKILL.md");
+
+/** Returns true when the installed SKILL.md differs from the bundled one. */
+async function isSkillMdStale(): Promise<boolean> {
+  try {
+    const [installed, bundled] = await Promise.all([
+      readFile(installedSkillMdPath, "utf-8"),
+      readFile(await bundledSkillMdPath(), "utf-8"),
+    ]);
+    return installed !== bundled;
+  } catch {
+    return false;
+  }
+}
+
 // ─── install ──────────────────────────────────────────────────────────────────
 program
   .command("install")
-  .description("Register the capture hook in your Claude Code settings")
-  .option("--project", "Install into .claude/settings.json (project-level) instead of global")
+  .description("Register the capture hook and install/update the skill in Claude Code")
+  .option("--project", "Install hook into .claude/settings.json (project-level) instead of global")
   .action(async (opts) => {
     const settingsPath = opts.project
       ? resolve(".claude/settings.json")
       : join(homedir(), ".claude", "settings.json");
 
+    // ── 1. Hook registration (skip if already present) ──────────────────────
     let settings: Record<string, unknown> = {};
     try {
       settings = JSON.parse(await readFile(settingsPath, "utf-8"));
@@ -125,32 +149,36 @@ program
     const preToolUse = (hooks.PreToolUse ?? []) as Array<Record<string, unknown>>;
 
     if (preToolUse.some((h) => JSON.stringify(h).includes("cc-skill-trace"))) {
-      console.log(chalk.yellow("⚠  Hook already registered → " + settingsPath));
-      return;
+      console.log(chalk.gray("  Hook already registered → " + settingsPath));
+    } else {
+      preToolUse.push({
+        matcher: "Skill",
+        hooks: [{ type: "command", command: "cc-skill-trace hook-capture" }],
+      });
+      settings.hooks = { ...hooks, PreToolUse: preToolUse };
+      await writeSettingsAtomic(settingsPath, settings);
+      console.log(chalk.green("✓  Hook installed → " + settingsPath));
+      console.log(chalk.gray("  Restart Claude Code for the hook to take effect."));
     }
 
-    preToolUse.push({
-      matcher: "Skill",
-      hooks: [{ type: "command", command: "cc-skill-trace hook-capture" }],
-    });
-    settings.hooks = { ...hooks, PreToolUse: preToolUse };
-
-    await writeSettingsAtomic(settingsPath, settings);
-    console.log(chalk.green("✓  Hook installed → " + settingsPath));
-    console.log(chalk.gray("  Restart Claude Code for the hook to take effect."));
-
-    // Also install the skill
+    // ── 2. SKILL.md — always sync to the latest bundled version ─────────────
     const skillDir = join(homedir(), ".claude", "skills", "skill-trace");
     const { mkdir } = await import("node:fs/promises");
-    const { fileURLToPath } = await import("node:url");
-    const { dirname } = await import("node:path");
-    const here = dirname(fileURLToPath(import.meta.url));
-    const skillSrc = join(here, "..", "skill", "SKILL.md");
+    const skillSrc = await bundledSkillMdPath();
     try {
+      const bundled = await readFile(skillSrc, "utf-8");
+      const installed = await readFile(installedSkillMdPath, "utf-8").catch(() => null);
       await mkdir(skillDir, { recursive: true });
-      await fsCopyFile(skillSrc, join(skillDir, "SKILL.md"));
-      console.log(chalk.green("✓  Skill installed   → " + skillDir));
-      console.log(chalk.gray("  Use /skill-trace inside Claude Code to open the dashboard."));
+      await fsCopyFile(skillSrc, installedSkillMdPath);
+      if (installed === null) {
+        console.log(chalk.green("✓  Skill installed   → " + skillDir));
+        console.log(chalk.gray("  Use /skill-trace inside Claude Code to open the dashboard."));
+      } else if (installed !== bundled) {
+        console.log(chalk.green("✓  SKILL.md updated  → " + skillDir));
+        console.log(chalk.gray("  Restart Claude Code to apply the updated skill definition."));
+      } else {
+        console.log(chalk.gray("  SKILL.md already up to date."));
+      }
     } catch {
       console.log(chalk.yellow("  Skill file not found — run from the package root or install from npm."));
     }
@@ -233,6 +261,13 @@ program
   .option("--follow", "Refresh dashboard every 2s (live tail)")
   .action(async (opts) => {
     validateDateRange(opts.since, opts.before);
+
+    // Warn when the installed SKILL.md is out of date with the current package.
+    if (await isSkillMdStale()) {
+      process.stderr.write(
+        chalk.yellow("⚠  SKILL.md is outdated — run: cc-skill-trace install\n\n")
+      );
+    }
 
     if (opts.scan) {
       const { events: scanned, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -194,7 +194,8 @@ export async function extractAllInvocations(opts: {
   const allEvents: SkillInvocationEvent[] = [];
   let done = 0;
 
-  await mapWithLimit(files, 8, async (file) => {
+  const concurrency = Math.max(1, parseInt(process.env["CC_SCAN_CONCURRENCY"] ?? "8", 10) || 8);
+  await mapWithLimit(files, concurrency, async (file) => {
     try {
       const events = await extractInvocationsFromFile(file);
       for (const ev of events) {

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -8,28 +8,9 @@ description: >
 user-invocable: true
 ---
 
-# skill-trace
-
-## Step 1 — Check installation
-
 ```bash
-which cc-skill-trace 2>/dev/null || echo "NOT_INSTALLED"
+which cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED — run: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
+cc-skill-trace show --scan --compact -n 15 2>&1
 ```
 
-If `NOT_INSTALLED`: tell the user to run `npm install -g cc-skill-trace && cc-skill-trace install` then restart Claude Code. Stop here.
-
-## Step 2 — Show dashboard
-
-```bash
-cc-skill-trace show --scan --compact 2>&1
-```
-
-Show the output verbatim in a fenced code block (no language tag).
-
-## Step 3 — Interpret
-
-Provide a 2–3 line summary covering:
-- Auto-trigger rate (if >80%, note it costs context tokens and skill descriptions may be too broad)
-- Any skill appearing auto-triggered without clear user intent (flag as candidate for narrowing its `description:`)
-
-Offer follow-ups: `cc-skill-trace report` for browser charts, `--skill <name>` to drill in, `--since <YYYY-MM-DD>` to filter by date.
+Show output verbatim in a code block. Then in 2 sentences: state the auto-trigger rate and flag any skill auto-fired without clear user intent (suggest narrowing its `description:`). Offer: `report` for charts, `--skill <name>`, `--since YYYY-MM-DD`.

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: skill-trace
 description: >
-  Show which Claude Code skills were invoked, when, and why (auto vs user).
-  Invoke ONLY when the user explicitly asks about skill invocation history,
-  unexpected skill triggers, or types /skill-trace.
-  Do NOT invoke for general questions about skills or token usage.
+  Skill invocation history for Claude Code (auto vs user).
+  Invoke ONLY on explicit user request about skill history or /skill-trace.
+  Skip general skill or token questions.
 user-invocable: true
 ---
 
 ```bash
-which cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED — run: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
-cc-skill-trace show --scan --compact -n 15 2>&1
+which cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
+cc-skill-trace show --scan --terse -n 15 2>/dev/null
 ```
 
-Show output verbatim in a code block. Then in 2 sentences: state the auto-trigger rate and flag any skill auto-fired without clear user intent (suggest narrowing its `description:`). Offer: `report` for charts, `--skill <name>`, `--since YYYY-MM-DD`.
+Show output verbatim. 2-sentence summary: auto-trigger rate; any skill auto-fired without clear user intent (suggest narrowing its `description:`). Offer: `report`, `--skill <name>`, `--since YYYY-MM-DD`.


### PR DESCRIPTION
## Summary

- **OSS infra**: CODE_OF_CONDUCT, .editorconfig, SUPPORT.md, GitHub Discussions template, Question issue template, CI badge, corrected release instructions
- **Bug fixes**: filter consistency in `report`/`stats`/`export`, `--since > --before` validation, CSV header quoting, missing `injectedTokens` in CSV export
- **New features**: `list-skills` command, `show --json`, `CC_DEBUG=1`, `CC_SCAN_CONCURRENCY` env var, dashboard now shows `cwd`/token metadata
- **Docs**: CLAUDE.md architecture fix, Environment Variables table in README, `triggerMessage` limitation documented

## Changes

### OSS Infrastructure
- `CODE_OF_CONDUCT.md` — community standards
- `.editorconfig` — consistent indentation/line endings for contributors
- `SUPPORT.md` — help channels (Issues, Discussions, SECURITY.md)
- `.github/ISSUE_TEMPLATE/question.yml` — "Question / Help" issue template
- `.github/ISSUE_TEMPLATE/config.yml` — GitHub Discussions link added
- `CONTRIBUTING.md` — links to CODE_OF_CONDUCT and SUPPORT
- `README.md` — CI badge, corrected release instructions (workflow_dispatch, not tag push)

### Bug Fixes
- `report`, `stats`, `export` now pass filter options to `readEvents` directly instead of loading all events and filtering in memory — more efficient and consistent with `show`
- `--since > --before` now exits immediately with a clear error message
- CSV export: headers are now quoted; `injectedTokens` column added
- `CLAUDE.md`: corrected architecture — `hook-capture` is a CLI sub-command in `src/cli/index.ts`, not `src/hook/capture.ts`

### New Features

| Feature | Description |
|---|---|
| `list-skills` / `ls` | List all unique skills with total/auto/user counts; `--json` for machine-readable output |
| `show --json` | Output filtered events as a JSON array (pipe-friendly) |
| `CC_DEBUG=1` | Enable debug logging in `hook-capture` written to stderr (never blocks Claude Code) |
| `CC_SCAN_CONCURRENCY` | Tune parallel file reads during scan (default: 8) |
| Dashboard metadata | `cwd` and `~N tokens` shown inline in recent invocations when available |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm test` passes (35/35)
- [ ] `cc-skill-trace list-skills` — shows unique skills
- [ ] `cc-skill-trace show --json | jq length` — JSON output works
- [ ] `CC_DEBUG=1 cc-skill-trace hook-capture` — debug logs appear on stderr
- [ ] `cc-skill-trace show --since 2026-04-30 --before 2026-04-01` — error message shown
- [ ] `cc-skill-trace export --format csv` — headers quoted, injectedTokens column present

🤖 Generated with [Claude Code](https://claude.com/claude-code)