### PR TITLE
chore: add Biome linter/formatter, tighten tsconfig, strengthen CI (#20 #21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,7 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build
+      - run: npm audit --audit-level=high
+      - run: npm run lint
+      - run: npm run format:check
       - run: npm test

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "!!**/*.test.ts", "!!**/dist"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noControlCharactersInRegex": "off",
+        "noAssignInExpressions": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,13 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "lint": "biome lint src",
+    "lint:fix": "biome lint src --write",
+    "format": "biome format src --write",
+    "format:check": "biome format src",
     "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
     "prepare": "npm run build",
-    "prepublishOnly": "npm run typecheck && npm test"
+    "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },
   "dependencies": {
     "chalk": "^5.3.0",

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -24,23 +24,29 @@ export function vlen(s: string): number {
   for (const { segment } of _segmenter.segment(plain)) {
     const cp = segment.codePointAt(0) ?? 0;
     // Lone ZWJ or variation selectors that start a segment are zero-width
-    if (cp === 0x200D || cp === 0xFE0F || cp === 0xFE0E) continue;
+    if (cp === 0x200d || cp === 0xfe0f || cp === 0xfe0e) continue;
     // Keycap sequences (1️⃣ #️⃣): base char is ASCII but renders 2 columns wide
-    if (segment.includes("\u20E3")) { len += 2; continue; }
+    if (segment.includes("\u20E3")) {
+      len += 2;
+      continue;
+    }
     // Text→emoji via VS16 (©️ ™️): base char not in emoji range but renders 2 wide
-    if (segment.includes("\uFE0F")) { len += 2; continue; }
+    if (segment.includes("\uFE0F")) {
+      len += 2;
+      continue;
+    }
     // Wide chars: CJK ideographs, Hangul, fullwidth forms, emoji block
     if (
-      (cp >= 0x1100 && cp <= 0x115F) ||
-      (cp >= 0x2E80 && cp <= 0x303E) ||
-      (cp >= 0x3040 && cp <= 0xA4CF) ||
-      (cp >= 0xAC00 && cp <= 0xD7A3) ||
-      (cp >= 0xF900 && cp <= 0xFAFF) ||
-      (cp >= 0xFE10 && cp <= 0xFE1F) ||
-      (cp >= 0xFE30 && cp <= 0xFE4F) ||
-      (cp >= 0xFF00 && cp <= 0xFF60) ||
-      (cp >= 0xFFE0 && cp <= 0xFFE6) ||
-      (cp >= 0x1F300 && cp <= 0x1FAFF)
+      (cp >= 0x1100 && cp <= 0x115f) ||
+      (cp >= 0x2e80 && cp <= 0x303e) ||
+      (cp >= 0x3040 && cp <= 0xa4cf) ||
+      (cp >= 0xac00 && cp <= 0xd7a3) ||
+      (cp >= 0xf900 && cp <= 0xfaff) ||
+      (cp >= 0xfe10 && cp <= 0xfe1f) ||
+      (cp >= 0xfe30 && cp <= 0xfe4f) ||
+      (cp >= 0xff00 && cp <= 0xff60) ||
+      (cp >= 0xffe0 && cp <= 0xffe6) ||
+      (cp >= 0x1f300 && cp <= 0x1faff)
     ) {
       len += 2;
     } else {
@@ -62,7 +68,10 @@ function bar(ratio: number, width: number, color: (s: string) => string): string
 
 function fmtTime(iso: string): string {
   return new Date(iso).toLocaleTimeString(undefined, {
-    hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
   });
 }
 
@@ -74,10 +83,6 @@ function hr(char = "─"): string {
 
 function section(title: string): string {
   return chalk.bold.white(title);
-}
-
-function row(label: string, value: string): string {
-  return chalk.gray("  ") + padRight(label, 20) + value;
 }
 
 // ─── Stats bar chart ─────────────────────────────────────────────────────────
@@ -92,7 +97,8 @@ export interface SkillStat {
 export function buildStats(events: SkillInvocationEvent[]): SkillStat[] {
   const map: Record<string, SkillStat> = {};
   for (const ev of events) {
-    if (!map[ev.skillName]) map[ev.skillName] = { name: ev.skillName, total: 0, auto: 0, byUser: 0 };
+    if (!map[ev.skillName])
+      map[ev.skillName] = { name: ev.skillName, total: 0, auto: 0, byUser: 0 };
     map[ev.skillName].total++;
     if (ev.source === "claude") map[ev.skillName].auto++;
     else map[ev.skillName].byUser++;
@@ -124,7 +130,7 @@ export function renderStats(events: SkillInvocationEvent[]): string {
     if (ev.source === "claude") dayMap[day].auto++;
   }
   const days = Object.keys(dayMap).sort().slice(-14);
-  const maxDay = Math.max(...days.map(d => dayMap[d]!.total), 1);
+  const maxDay = Math.max(...days.map((d) => dayMap[d]!.total), 1);
   const dayBarW = 24;
 
   lines.push("");
@@ -133,14 +139,21 @@ export function renderStats(events: SkillInvocationEvent[]): string {
   for (const day of days) {
     const d = dayMap[day]!;
     const autoB = "█".repeat(Math.round((d.auto / maxDay) * dayBarW));
-    const userFill = Math.min(dayBarW - autoB.length, Math.round(((d.total - d.auto) / maxDay) * dayBarW));
+    const userFill = Math.min(
+      dayBarW - autoB.length,
+      Math.round(((d.total - d.auto) / maxDay) * dayBarW)
+    );
     const userB = "█".repeat(userFill);
     const emptyB = "░".repeat(Math.max(0, dayBarW - autoB.length - userB.length));
     const label = padRight(chalk.gray(day), 12);
     lines.push(
-      "  " + label + "  " +
-      chalk.magenta(autoB) + chalk.cyan(userB) + chalk.gray(emptyB) +
-      chalk.bold.white(`  ${d.total}x`)
+      "  " +
+        label +
+        "  " +
+        chalk.magenta(autoB) +
+        chalk.cyan(userB) +
+        chalk.gray(emptyB) +
+        chalk.bold.white(`  ${d.total}x`)
     );
   }
 
@@ -179,10 +192,7 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
 
   // ── header ──
   lines.push(hr("═"));
-  lines.push(
-    chalk.bold.white("  🔍 cc-skill-trace ") +
-    chalk.gray("─ Skill Invocation Debugger")
-  );
+  lines.push(chalk.bold.white("  🔍 cc-skill-trace ") + chalk.gray("─ Skill Invocation Debugger"));
   lines.push(hr("─"));
 
   if (events.length === 0) {
@@ -199,19 +209,23 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
   }
 
   // ── summary stats ──
-  const total   = events.length;
-  const autoCnt = events.filter(e => e.source === "claude").length;
+  const total = events.length;
+  const autoCnt = events.filter((e) => e.source === "claude").length;
   const userCnt = total - autoCnt;
   const autoRate = Math.round((autoCnt / total) * 100);
-  const uniqueSkills = new Set(events.map(e => e.skillName)).size;
+  const uniqueSkills = new Set(events.map((e) => e.skillName)).size;
 
   lines.push("");
   lines.push(
     chalk.gray("  ") +
-    chalk.bold.white(String(total).padStart(4)) + chalk.gray(" invocations   ") +
-    chalk.magenta(String(autoCnt).padStart(3)) + chalk.gray(" 🤖 auto   ") +
-    chalk.cyan(String(userCnt).padStart(3)) + chalk.gray(" 👤 user   ") +
-    chalk.yellow(String(uniqueSkills).padStart(3)) + chalk.gray(" unique skills")
+      chalk.bold.white(String(total).padStart(4)) +
+      chalk.gray(" invocations   ") +
+      chalk.magenta(String(autoCnt).padStart(3)) +
+      chalk.gray(" 🤖 auto   ") +
+      chalk.cyan(String(userCnt).padStart(3)) +
+      chalk.gray(" 👤 user   ") +
+      chalk.yellow(String(uniqueSkills).padStart(3)) +
+      chalk.gray(" unique skills")
   );
   lines.push("");
 
@@ -220,8 +234,8 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
   const rateColor = autoRate >= 70 ? chalk.magenta : chalk.cyan;
   lines.push(
     chalk.gray("  🤖 Auto-trigger  ") +
-    bar(autoRate / 100, rateBarW, rateColor) +
-    chalk.bold.white(`  ${autoRate}%`)
+      bar(autoRate / 100, rateBarW, rateColor) +
+      chalk.bold.white(`  ${autoRate}%`)
   );
   lines.push("");
   lines.push(hr("─"));
@@ -230,25 +244,29 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
   const stats = buildStats(events);
   const maxTotal = stats[0]?.total ?? 1;
   const barW = 24;
-  const nameW = Math.min(22, Math.max(8, ...stats.map(s => s.name.length)) + 1);
+  const nameW = Math.min(22, Math.max(8, ...stats.map((s) => s.name.length)) + 1);
 
   lines.push("");
   lines.push(section("  📊 Skills"));
   lines.push("");
 
   for (const s of stats.slice(0, 8)) {
-    const autoB  = "█".repeat(Math.round((s.auto   / maxTotal) * barW));
+    const autoB = "█".repeat(Math.round((s.auto / maxTotal) * barW));
     const userFill = Math.min(barW - autoB.length, Math.round((s.byUser / maxTotal) * barW));
-    const userB  = "█".repeat(userFill);
+    const userB = "█".repeat(userFill);
     const emptyB = "░".repeat(Math.max(0, barW - autoB.length - userB.length));
     const nameLabel = padRight(chalk.bold.yellow(s.name), nameW + 9 /* ansi overhead approx */);
     lines.push(
-      "  " + nameLabel + "  " +
-      chalk.magenta(autoB) + chalk.cyan(userB) + chalk.gray(emptyB) +
-      chalk.bold.white(`  ${s.total}x`) +
-      chalk.gray(`  ${s.auto}auto`) +
-      chalk.gray(` · `) +
-      chalk.gray(`${s.byUser}user`)
+      "  " +
+        nameLabel +
+        "  " +
+        chalk.magenta(autoB) +
+        chalk.cyan(userB) +
+        chalk.gray(emptyB) +
+        chalk.bold.white(`  ${s.total}x`) +
+        chalk.gray(`  ${s.auto}auto`) +
+        chalk.gray(` · `) +
+        chalk.gray(`${s.byUser}user`)
     );
   }
 
@@ -256,21 +274,17 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
   lines.push(hr("─"));
 
   // ── recent timeline ──
-  const recent = [...events]
-    .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
-    .slice(0, 12);
+  const recent = [...events].sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, 12);
 
   lines.push("");
   lines.push(section("  🕐 Recent invocations") + chalk.gray("  (newest first)"));
   lines.push("");
 
   for (const ev of recent) {
-    const dot  = ev.source === "claude" ? chalk.magenta("●") : chalk.cyan("●");
+    const dot = ev.source === "claude" ? chalk.magenta("●") : chalk.cyan("●");
     const time = chalk.gray(fmtTime(ev.timestamp));
     const name = padRight(chalk.bold.yellow(ev.skillName), nameW + 9);
-    const src  = ev.source === "claude"
-      ? chalk.magenta("🤖 auto")
-      : chalk.cyan("👤 user");
+    const src = ev.source === "claude" ? chalk.magenta("🤖 auto") : chalk.cyan("👤 user");
 
     const maxTriggerW = Math.max(10, W() - nameW - 36);
     const trigger = ev.triggerMessage
@@ -278,7 +292,7 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
       : chalk.gray("(no trigger context)");
 
     const meta: string[] = [];
-    if (ev.cwd)            meta.push(chalk.gray(`  cwd: ${ev.cwd}`));
+    if (ev.cwd) meta.push(chalk.gray(`  cwd: ${ev.cwd}`));
     if (ev.injectedTokens) meta.push(chalk.gray(`  ~${ev.injectedTokens.toLocaleString()} tokens`));
     const metaLine = meta.length ? "\n       " + meta.join("  ") : "";
 
@@ -287,7 +301,11 @@ export function renderDashboard(events: SkillInvocationEvent[]): string {
 
   lines.push("");
   lines.push(hr("─"));
-  lines.push(chalk.gray("  ") + chalk.underline.gray("cc-skill-trace report") + chalk.gray("  → interactive browser dashboard"));
+  lines.push(
+    chalk.gray("  ") +
+      chalk.underline.gray("cc-skill-trace report") +
+      chalk.gray("  → interactive browser dashboard")
+  );
   lines.push(hr("═"));
 
   return lines.join("\n");
@@ -318,21 +336,26 @@ export function renderTerse(events: SkillInvocationEvent[]): string {
     return "0 events. Run: cc-skill-trace install then restart Claude Code.";
   }
 
-  const total  = events.length;
-  const auto   = events.filter(e => e.source === "claude").length;
-  const rate   = Math.round((auto / total) * 100);
+  const total = events.length;
+  const auto = events.filter((e) => e.source === "claude").length;
+  const rate = Math.round((auto / total) * 100);
   const skills = buildStats(events);
 
   // "11ev 72%auto | commit:5(4a) review:3(2a) …"
-  const skillSummary = skills.slice(0, 8)
-    .map(s => `${s.name}:${s.total}(${s.auto}a)`)
+  const skillSummary = skills
+    .slice(0, 8)
+    .map((s) => `${s.name}:${s.total}(${s.auto}a)`)
     .join(" ");
   const lines: string[] = [`${total}ev ${rate}%auto | ${skillSummary}`];
 
   // "14:34 commit auto "trigger text""
   for (const ev of [...events].sort((a, b) => b.timestamp.localeCompare(a.timestamp))) {
-    const t    = new Date(ev.timestamp).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", hour12: false });
-    const src  = ev.source === "claude" ? "auto" : "user";
+    const t = new Date(ev.timestamp).toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    const src = ev.source === "claude" ? "auto" : "user";
     const trig = ev.triggerMessage
       ? ` "${ev.triggerMessage.replace(/\n/g, " ").slice(0, 40)}"`
       : "";

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ const _nodeMajor = parseInt(process.versions.node.split(".")[0]!, 10);
 if (_nodeMajor < 18) {
   process.stderr.write(
     `\ncc-skill-trace requires Node.js ≥ 18. You are running ${process.version}.\n` +
-    `Upgrade at https://nodejs.org\n\n`
+      `Upgrade at https://nodejs.org\n\n`
   );
   process.exit(1);
 }
@@ -29,7 +29,9 @@ const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T[\d:.Z+-]*)?$/;
 
 function validateSince(value: string): string {
   if (!ISO_DATE_RE.test(value) || isNaN(Date.parse(value))) {
-    console.error(chalk.red(`✗  Invalid date value: "${value}". Expected ISO date, e.g. 2026-04-01`));
+    console.error(
+      chalk.red(`✗  Invalid date value: "${value}". Expected ISO date, e.g. 2026-04-01`)
+    );
     process.exit(1);
   }
   return value;
@@ -38,7 +40,9 @@ function validateSince(value: string): string {
 function validateLimit(value: string): string {
   const n = parseInt(value, 10);
   if (isNaN(n) || n < 1 || String(n) !== value.trim()) {
-    console.error(chalk.red(`✗  Invalid --limit value: "${value}". Expected a positive integer, e.g. 50`));
+    console.error(
+      chalk.red(`✗  Invalid --limit value: "${value}". Expected a positive integer, e.g. 50`)
+    );
     process.exit(1);
   }
   return value;
@@ -60,9 +64,13 @@ function validateDateRange(since: string | undefined, before: string | undefined
  */
 async function writeSettingsAtomic(path: string, data: unknown): Promise<void> {
   const json = JSON.stringify(data, null, 2);
-  const tmp  = path + ".tmp";
+  const tmp = path + ".tmp";
   // Best-effort backup — don't fail if the original doesn't exist yet
-  try { await fsCopyFile(path, path + ".bak"); } catch { /* no original yet */ }
+  try {
+    await fsCopyFile(path, path + ".bak");
+  } catch {
+    /* no original yet */
+  }
   await writeFile(tmp, json, "utf-8");
   await rename(tmp, path);
 }
@@ -81,7 +89,10 @@ async function scanAndMerge(opts: {
   const existingIds = new Set((await readEvents()).map((e) => e.id));
   let imported = 0;
   for (const ev of events) {
-    if (!existingIds.has(ev.id)) { await appendEvent(ev); imported++; }
+    if (!existingIds.has(ev.id)) {
+      await appendEvent(ev);
+      imported++;
+    }
   }
   return { events, imported };
 }
@@ -143,7 +154,9 @@ program
     let settings: Record<string, unknown> = {};
     try {
       settings = JSON.parse(await readFile(settingsPath, "utf-8"));
-    } catch { /* start fresh */ }
+    } catch {
+      /* start fresh */
+    }
 
     const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
     const preToolUse = (hooks.PreToolUse ?? []) as Array<Record<string, unknown>>;
@@ -180,7 +193,9 @@ program
         console.log(chalk.gray("  SKILL.md already up to date."));
       }
     } catch {
-      console.log(chalk.yellow("  Skill file not found — run from the package root or install from npm."));
+      console.log(
+        chalk.yellow("  Skill file not found — run from the package root or install from npm.")
+      );
     }
   });
 
@@ -191,7 +206,9 @@ program
   .helpOption(false)
   .action(async () => {
     const DEBUG = process.env["CC_DEBUG"] === "1";
-    const dbg = (msg: string) => { if (DEBUG) process.stderr.write(`[cc-skill-trace] ${msg}\n`); };
+    const dbg = (msg: string) => {
+      if (DEBUG) process.stderr.write(`[cc-skill-trace] ${msg}\n`);
+    };
 
     let raw = "";
     const MAX_STDIN_BYTES = 1024 * 64; // 64 KB — hook payloads are tiny
@@ -240,8 +257,15 @@ program
       gitBranch: payload.git_branch,
     };
 
-    dbg(`capturing ${event.source} invocation of "${event.skillName}" in session ${event.sessionId}`);
-    try { await appendEvent(event); dbg("event appended"); } catch (err) { dbg(`appendEvent failed: ${err}`); }
+    dbg(
+      `capturing ${event.source} invocation of "${event.skillName}" in session ${event.sessionId}`
+    );
+    try {
+      await appendEvent(event);
+      dbg("event appended");
+    } catch (err) {
+      dbg(`appendEvent failed: ${err}`);
+    }
     process.stdout.write(JSON.stringify({}));
     process.exit(0);
   });
@@ -271,8 +295,15 @@ program
     }
 
     if (opts.scan) {
-      const { events: scanned, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
-      process.stderr.write(chalk.gray(`  Imported ${imported} new invocations (${scanned.length - imported} already stored).\n\n`));
+      const { events: scanned, imported } = await scanAndMerge({
+        since: opts.since,
+        sessionId: opts.session,
+      });
+      process.stderr.write(
+        chalk.gray(
+          `  Imported ${imported} new invocations (${scanned.length - imported} already stored).\n\n`
+        )
+      );
     }
 
     const readOpts = {
@@ -291,13 +322,23 @@ program
         if (newTs !== lastEventTs) {
           lastEventTs = newTs;
           process.stdout.write("\x1B[2J\x1B[0f"); // clear screen, cursor home
-          process.stdout.write((opts.compact ? renderCompact(events) : renderDashboard(events)) + "\n");
+          process.stdout.write(
+            (opts.compact ? renderCompact(events) : renderDashboard(events)) + "\n"
+          );
         }
-        process.stdout.write(chalk.gray(`  [Following — Ctrl+C to exit] `) + chalk.gray(new Date().toLocaleTimeString()) + "  \r");
+        process.stdout.write(
+          chalk.gray(`  [Following — Ctrl+C to exit] `) +
+            chalk.gray(new Date().toLocaleTimeString()) +
+            "  \r"
+        );
       };
       await tick();
       const interval = setInterval(tick, 2000);
-      const cleanup = () => { clearInterval(interval); process.stdout.write("\n"); process.exit(0); };
+      const cleanup = () => {
+        clearInterval(interval);
+        process.stdout.write("\n");
+        process.exit(0);
+      };
       process.on("SIGINT", cleanup);
       process.on("SIGTERM", cleanup);
       return;
@@ -327,13 +368,23 @@ program
   .option("--clear", "Clear existing events before scanning")
   .action(async (opts) => {
     validateDateRange(opts.since, opts.before);
-    if (opts.clear) { await clearEvents(); console.log(chalk.gray("  Cleared.")); }
+    if (opts.clear) {
+      await clearEvents();
+      console.log(chalk.gray("  Cleared."));
+    }
     const { events, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
     let filtered = events;
-    if (opts.before) filtered = filtered.filter(e => e.timestamp <= opts.before);
-    if (opts.skill)  filtered = filtered.filter(e => e.skillName === opts.skill);
-    if (filtered.length === 0) { console.log(chalk.yellow("  No invocations found.")); return; }
-    console.log(chalk.green(`✓  Imported ${imported} new invocations (${events.length - imported} already stored).`));
+    if (opts.before) filtered = filtered.filter((e) => e.timestamp <= opts.before);
+    if (opts.skill) filtered = filtered.filter((e) => e.skillName === opts.skill);
+    if (filtered.length === 0) {
+      console.log(chalk.yellow("  No invocations found."));
+      return;
+    }
+    console.log(
+      chalk.green(
+        `✓  Imported ${imported} new invocations (${events.length - imported} already stored).`
+      )
+    );
     console.log("\n" + renderDashboard(filtered));
   });
 
@@ -351,7 +402,10 @@ program
   .action(async (opts) => {
     validateDateRange(opts.since, opts.before);
     if (opts.scan) {
-      const { events: scanned, imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
+      const { events: scanned, imported } = await scanAndMerge({
+        since: opts.since,
+        sessionId: opts.session,
+      });
       console.log(chalk.gray(`  Scanned: ${scanned.length} invocations (${imported} new).`));
     }
     const events = await readEvents({
@@ -374,7 +428,9 @@ program
         } else {
           execFileSync("xdg-open", [opts.output], { stdio: "ignore" });
         }
-      } catch { console.log(chalk.gray(`  Open manually: ${opts.output}`)); }
+      } catch {
+        console.log(chalk.gray(`  Open manually: ${opts.output}`));
+      }
     }
   });
 
@@ -387,7 +443,9 @@ program
     if (opts.olderThan) {
       const cutoff = parseDuration(String(opts.olderThan));
       const { removed, kept } = await pruneEvents(cutoff.toISOString());
-      console.log(chalk.green(`✓  Removed ${removed} events older than ${opts.olderThan} (${kept} kept).`));
+      console.log(
+        chalk.green(`✓  Removed ${removed} events older than ${opts.olderThan} (${kept} kept).`)
+      );
     } else {
       await clearEvents();
       console.log(chalk.green("✓  Cleared."));
@@ -446,18 +504,30 @@ program
     let out: string;
 
     if (fmt === "csv") {
-      const headers: (keyof typeof events[0])[] = [
-        "id", "timestamp", "sessionId", "skillName", "skillArgs",
-        "source", "triggerMessage", "injectedTokens", "cwd", "gitBranch",
+      const headers: (keyof (typeof events)[0])[] = [
+        "id",
+        "timestamp",
+        "sessionId",
+        "skillName",
+        "skillArgs",
+        "source",
+        "triggerMessage",
+        "injectedTokens",
+        "cwd",
+        "gitBranch",
       ];
       const esc = (v: unknown) => {
         const s = v == null ? "" : String(v);
         return s.includes(",") || s.includes('"') || s.includes("\n")
-          ? `"${s.replace(/"/g, '""')}"` : s;
+          ? `"${s.replace(/"/g, '""')}"`
+          : s;
       };
       // UTF-8 BOM ensures Excel opens the file without garbling non-ASCII characters
-      out = "\uFEFF" + headers.map(h => `"${h}"`).join(",") + "\n"
-        + events.map(e => headers.map(h => esc(e[h])).join(",")).join("\n");
+      out =
+        "\uFEFF" +
+        headers.map((h) => `"${h}"`).join(",") +
+        "\n" +
+        events.map((e) => headers.map((h) => esc(e[h])).join(",")).join("\n");
     } else if (fmt === "json") {
       out = JSON.stringify(events, null, 2);
     } else {
@@ -506,17 +576,20 @@ program
       return;
     }
 
-    const maxName = Math.max(...stats.map(s => s.name.length));
-    console.log(
-      chalk.gray("  " + "skill".padEnd(maxName) + "   total  auto  user")
-    );
+    const maxName = Math.max(...stats.map((s) => s.name.length));
+    console.log(chalk.gray("  " + "skill".padEnd(maxName) + "   total  auto  user"));
     console.log(chalk.gray("  " + "─".repeat(maxName + 20)));
     for (const s of stats) {
       console.log(
-        "  " + chalk.bold.yellow(s.name.padEnd(maxName)) +
-        "  " + chalk.white(String(s.total).padStart(5)) + chalk.gray("x") +
-        "  " + chalk.magenta(String(s.auto).padStart(4)) +
-        "  " + chalk.cyan(String(s.byUser).padStart(4))
+        "  " +
+          chalk.bold.yellow(s.name.padEnd(maxName)) +
+          "  " +
+          chalk.white(String(s.total).padStart(5)) +
+          chalk.gray("x") +
+          "  " +
+          chalk.magenta(String(s.auto).padStart(4)) +
+          "  " +
+          chalk.cyan(String(s.byUser).padStart(4))
       );
     }
   });
@@ -541,7 +614,7 @@ program
 
     const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
     const preToolUse = (hooks.PreToolUse ?? []) as Array<Record<string, unknown>>;
-    const filtered = preToolUse.filter(h => !JSON.stringify(h).includes("cc-skill-trace"));
+    const filtered = preToolUse.filter((h) => !JSON.stringify(h).includes("cc-skill-trace"));
 
     if (filtered.length === preToolUse.length) {
       console.log(chalk.yellow("⚠  Hook not found in: " + settingsPath));

--- a/src/cli/web-report.ts
+++ b/src/cli/web-report.ts
@@ -46,9 +46,9 @@ export function buildHtmlReport(events: SkillInvocationEvent[]): string {
   }
 
   // ── JSON data embedded in the page ───────────────────────────────────────
-  const eventsJson    = safeJson(events);
+  const eventsJson = safeJson(events);
   const topSkillsJson = safeJson(topSkills);
-  const byDayJson     = safeJson(
+  const byDayJson = safeJson(
     Object.entries(byDay).map(([day, evs]) => ({ day, count: evs.length }))
   );
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -3,7 +3,13 @@ import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 import { createInterface } from "node:readline";
-import type { SessionLogEntry, SkillInvocationEvent, ToolUse, ToolResult, ContentBlock } from "./types.js";
+import type {
+  SessionLogEntry,
+  SkillInvocationEvent,
+  ToolUse,
+  ToolResult,
+  ContentBlock,
+} from "./types.js";
 
 // Read at call time so tests and CLI can override via CC_PROJECTS_DIR at runtime (#38)
 function getProjectsDir(): string {
@@ -19,7 +25,7 @@ function escapeRegExp(s: string): string {
 async function mapWithLimit<T, R>(
   items: T[],
   limit: number,
-  fn: (item: T) => Promise<R>,
+  fn: (item: T) => Promise<R>
 ): Promise<R[]> {
   const results: (R | undefined)[] = new Array(items.length);
   let next = 0;
@@ -133,7 +139,7 @@ export async function extractInvocationsFromFile(
       const bareSkillName = skillName.includes(":") ? skillName.split(":").pop()! : skillName;
       const slashCmdRe = new RegExp(
         `^/(${escapeRegExp(skillName)}|${escapeRegExp(bareSkillName)})(\\s|$)`,
-        "i",
+        "i"
       );
       const isUserInvoked = slashCmdRe.test(triggerMessage?.trimStart() ?? "");
 
@@ -150,12 +156,13 @@ export async function extractInvocationsFromFile(
           (b): b is ToolResult => b.type === "tool_result" && b.tool_use_id === call.id
         );
         if (result) {
-          const text = typeof result.content === "string"
-            ? result.content
-            : (result.content as Array<{ type: string; text?: string }>)
-                .filter((b) => b.type === "text")
-                .map((b) => b.text ?? "")
-                .join("");
+          const text =
+            typeof result.content === "string"
+              ? result.content
+              : (result.content as Array<{ type: string; text?: string }>)
+                  .filter((b) => b.type === "text")
+                  .map((b) => b.text ?? "")
+                  .join("");
           if (text) injectedTokens = Math.round(text.length / 4);
           break;
         }
@@ -185,11 +192,13 @@ export async function extractInvocationsFromFile(
  * Pass `since` (ISO string) to limit to recent sessions.
  * Pass `onProgress` to receive (done, total) updates during scanning.
  */
-export async function extractAllInvocations(opts: {
-  since?: string;
-  sessionId?: string;
-  onProgress?: (done: number, total: number) => void;
-} = {}): Promise<SkillInvocationEvent[]> {
+export async function extractAllInvocations(
+  opts: {
+    since?: string;
+    sessionId?: string;
+    onProgress?: (done: number, total: number) => void;
+  } = {}
+): Promise<SkillInvocationEvent[]> {
   const files = await findAllSessionFiles();
   const allEvents: SkillInvocationEvent[] = [];
   let done = 0;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -19,9 +19,18 @@ const writeQueues = new Map<string, Promise<void>>();
 
 function enqueueWrite<T = void>(dir: string, fn: () => Promise<T>): Promise<T> {
   const prev = writeQueues.get(dir) ?? Promise.resolve();
-  const next = prev.then(() => fn(), () => fn());
+  const next = prev.then(
+    () => fn(),
+    () => fn()
+  );
   // Store a void chain so the queue type stays consistent
-  writeQueues.set(dir, next.then(() => {}, () => {}));
+  writeQueues.set(
+    dir,
+    next.then(
+      () => {},
+      () => {}
+    )
+  );
   return next;
 }
 
@@ -61,7 +70,9 @@ export function appendEvent(event: SkillInvocationEvent, dir = STORE_DIR): Promi
  * Accepts either a legacy `readEvents(dirString)` call or the new
  * `readEvents(options)` form — both are supported for backward compatibility.
  */
-export async function readEvents(opts: ReadEventsOptions | string = {}): Promise<SkillInvocationEvent[]> {
+export async function readEvents(
+  opts: ReadEventsOptions | string = {}
+): Promise<SkillInvocationEvent[]> {
   // Legacy: readEvents(dirString)
   const options: ReadEventsOptions = typeof opts === "string" ? { dir: opts } : opts;
   const dir = options.dir ?? STORE_DIR;
@@ -79,9 +90,9 @@ export async function readEvents(opts: ReadEventsOptions | string = {}): Promise
     try {
       const ev = JSON.parse(line) as SkillInvocationEvent;
       // Apply filters at parse time — avoids accumulating excluded events in memory
-      if (options.since     && ev.timestamp  < options.since)     continue;
-      if (options.before    && ev.timestamp  > options.before)    continue;
-      if (options.skill     && ev.skillName !== options.skill)    continue;
+      if (options.since && ev.timestamp < options.since) continue;
+      if (options.before && ev.timestamp > options.before) continue;
+      if (options.skill && ev.skillName !== options.skill) continue;
       if (options.sessionId && ev.sessionId !== options.sessionId) continue;
       events.push(ev);
     } catch {
@@ -107,7 +118,7 @@ export function clearEvents(dir = STORE_DIR): Promise<void> {
  *  Returns counts of removed and kept events. */
 export function pruneEvents(
   beforeIso: string,
-  dir = STORE_DIR,
+  dir = STORE_DIR
 ): Promise<{ removed: number; kept: number }> {
   return enqueueWrite(dir, async () => {
     await ensureStoreDir(dir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,17 @@
-export type { SkillInvocationEvent, InvocationSource, HookPayload, SessionLogEntry } from "./core/types.js";
-export { readEvents, appendEvent, clearEvents, pruneEvents, STORE_DIR, EVENTS_FILE } from "./core/store.js";
+export type {
+  SkillInvocationEvent,
+  InvocationSource,
+  HookPayload,
+  SessionLogEntry,
+} from "./core/types.js";
+export {
+  readEvents,
+  appendEvent,
+  clearEvents,
+  pruneEvents,
+  STORE_DIR,
+  EVENTS_FILE,
+} from "./core/store.js";
 export { extractAllInvocations, extractInvocationsFromFile } from "./core/parser.js";
 export { buildStats } from "./cli/format.js";
 export { buildHtmlReport } from "./cli/web-report.js";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
- biome.json: Biome 2.4.13 config (space/2, lineWidth 100, recommended rules)
  disables noControlCharactersInRegex (intentional ANSI handling) and
  noAssignInExpressions (idiomatic ??= usage)
- package.json: add lint, lint:fix, format, format:check scripts;
  prepublishOnly now includes lint gate
- tsconfig.json: add noUnusedLocals, noUnusedParameters,
  forceConsistentCasingInFileNames; removed dead row() function in format.ts
- ci.yml: add npm audit --audit-level=high, biome lint, biome format check
  steps to every Node matrix job
- src/: auto-format all sources to satisfy biome format:check

https://claude.ai/code/session_01JYQqi9KShHX48M3kHsTmDn