### PR TITLE
fix: parseDuration に分単位 (min) を追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/duration.test.ts
+++ b/src/cli/duration.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseDuration } from "./duration.js";
+
+/** Elapsed milliseconds between the returned cutoff and "now", within tolerance. */
+function elapsedMs(cutoff: Date): number {
+  return Date.now() - cutoff.getTime();
+}
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+// Generous tolerance so the test is not flaky on slow CI.
+const TOL = 5 * MIN;
+
+describe("parseDuration", () => {
+  it("supports minutes (min)", () => {
+    assert.ok(Math.abs(elapsedMs(parseDuration("30min")) - 30 * MIN) < TOL);
+    assert.ok(Math.abs(elapsedMs(parseDuration("90min")) - 90 * MIN) < TOL);
+  });
+
+  it("supports hours (h)", () => {
+    assert.ok(Math.abs(elapsedMs(parseDuration("12h")) - 12 * HOUR) < TOL);
+  });
+
+  it("supports days (d)", () => {
+    assert.ok(Math.abs(elapsedMs(parseDuration("30d")) - 30 * DAY) < TOL);
+  });
+
+  it("supports weeks (w)", () => {
+    assert.ok(Math.abs(elapsedMs(parseDuration("4w")) - 4 * WEEK) < TOL);
+  });
+
+  it("is case-insensitive", () => {
+    assert.ok(Math.abs(elapsedMs(parseDuration("30MIN")) - 30 * MIN) < TOL);
+    assert.ok(Math.abs(elapsedMs(parseDuration("12H")) - 12 * HOUR) < TOL);
+  });
+});

--- a/src/cli/duration.ts
+++ b/src/cli/duration.ts
@@ -1,0 +1,28 @@
+import chalk from "chalk";
+
+/**
+ * Parse a human-friendly relative duration into a cutoff Date (now − duration).
+ *
+ * Supported units: `min` (minutes), `h` (hours), `d` (days), `w` (weeks).
+ * `min` is spelled out rather than `m` to avoid a future clash with months
+ * (`mo`, see #93).
+ *
+ * On invalid input, prints an error and exits the process (CLI behavior).
+ */
+export function parseDuration(value: string): Date {
+  const match = /^(\d+)(min|h|d|w)$/i.exec(value);
+  if (!match) {
+    console.error(
+      chalk.red(`✗  Invalid duration: "${value}". Expected format: 30min, 12h, 30d, or 4w`)
+    );
+    process.exit(1);
+  }
+  const n = parseInt(match[1]!, 10);
+  const unit = match[2]!.toLowerCase();
+  const cutoff = new Date();
+  if (unit === "min") cutoff.setMinutes(cutoff.getMinutes() - n);
+  else if (unit === "h") cutoff.setHours(cutoff.getHours() - n);
+  else if (unit === "d") cutoff.setDate(cutoff.getDate() - n);
+  else cutoff.setDate(cutoff.getDate() - n * 7);
+  return cutoff;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
+import { parseDuration } from "./duration.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -95,21 +96,6 @@ async function scanAndMerge(opts: {
     }
   }
   return { events, imported };
-}
-
-function parseDuration(value: string): Date {
-  const match = /^(\d+)(h|d|w)$/i.exec(value);
-  if (!match) {
-    console.error(chalk.red(`✗  Invalid duration: "${value}". Expected format: 12h, 30d, or 4w`));
-    process.exit(1);
-  }
-  const n = parseInt(match[1]!, 10);
-  const unit = match[2]!.toLowerCase();
-  const cutoff = new Date();
-  if (unit === "h") cutoff.setHours(cutoff.getHours() - n);
-  else if (unit === "d") cutoff.setDate(cutoff.getDate() - n);
-  else cutoff.setDate(cutoff.getDate() - n * 7);
-  return cutoff;
 }
 
 program
@@ -438,7 +424,7 @@ program
 program
   .command("clear")
   .description("Clear all captured events")
-  .option("--older-than <duration>", "Remove events older than this (e.g. 12h, 30d, 4w)")
+  .option("--older-than <duration>", "Remove events older than this (e.g. 30min, 12h, 30d, 4w)")
   .action(async (opts) => {
     if (opts.olderThan) {
       const cutoff = parseDuration(String(opts.olderThan));


### PR DESCRIPTION
## Summary

`clear --older-than` が分単位を受け付けず、`30min` のような自然な指定がエラーになっていた問題を修正します。`parseDuration` は `h` / `d` / `w` のみ対応で、分単位のユースケース（例: `cc-skill-trace clear --older-than 30min`）が使えませんでした。

Closes #185

### 妥当性検証

`src/cli/index.ts` の `parseDuration` を確認し、問題が現行コードで再現することを確認しました:

```ts
const match = /^(\d+)(h|d|w)$/i.exec(value);  // min 非対応
```

実際に `30m` / `30min` を渡すと `✗  Invalid duration...` でエラー終了することを再現確認済みです。`min` の単位は追加され、`m`（分）ではなく `min` を採用しています（月 `mo` #93 との衝突回避のため。issue の推奨どおり）。

## Changes

- `parseDuration` を単体テスト可能な独立モジュール `src/cli/duration.ts` に切り出し（`index.ts` は末尾で `program.parse()` を実行するためインポート不可だった）
- 正規表現を `/^(\d+)(min|h|d|w)$/i` に変更し、`min` → `setMinutes` による cutoff 計算を追加
- 無効入力時のエラーメッセージを `Expected format: 30min, 12h, 30d, or 4w` に更新
- `clear --older-than` のオプション説明に `30min` を追加
- 各単位（min / h / d / w、大文字含む）の単体テスト `src/cli/duration.test.ts` を追加し、`package.json` の `test` スクリプトに登録

## Test plan

- [x] `npm test` passes（40 tests, 0 fail）
- [x] `npm run typecheck` passes
- [x] Manually tested: `parseDuration('30min')` → 30分前、`'90min'` → 90分前、`'12h'`/`'30d'`/`'4w'` も従来どおり正しい cutoff を返すことを確認。無効な `'30m'` は更新後のメッセージでエラー終了することを確認。

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本変更は `clear` コマンドのみに影響し、hook-capture 経路は不変）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQ5bgGC5KKnxZo8qpJfxFo)_