### PR TITLE
fix: CC_PROJECTS_DIR の先頭チルダ (~/) をホームディレクトリに展開する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ src/
 - イベントストアは JSONL（SQLite は v2 で検討）
 - `CC_DEBUG=1` 環境変数で `hook-capture` のデバッグログを stderr に出力
 - `CC_SCAN_CONCURRENCY` 環境変数でスキャン並列数を変更（デフォルト: 8）
-- `CC_PROJECTS_DIR` 環境変数でスキャン対象ディレクトリを変更
+- `CC_PROJECTS_DIR` 環境変数でスキャン対象ディレクトリを変更（先頭の `~/` はホームディレクトリに展開される）
 
 ### hook-capture と triggerMessage の制限
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/core/utils.test.ts src/cli/format.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -3,6 +3,7 @@ import { readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 import { createInterface } from "node:readline";
+import { expandTilde } from "./utils.js";
 import type {
   SessionLogEntry,
   SkillInvocationEvent,
@@ -13,7 +14,8 @@ import type {
 
 // Read at call time so tests and CLI can override via CC_PROJECTS_DIR at runtime (#38)
 function getProjectsDir(): string {
-  return process.env["CC_PROJECTS_DIR"] ?? join(homedir(), ".claude", "projects");
+  const raw = process.env["CC_PROJECTS_DIR"] ?? join(homedir(), ".claude", "projects");
+  return expandTilde(raw);
 }
 
 function escapeRegExp(s: string): string {

--- a/src/core/utils.test.ts
+++ b/src/core/utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { expandTilde } from "./utils.js";
+
+describe("expandTilde", () => {
+  it("expands a bare ~ to the home directory", () => {
+    assert.equal(expandTilde("~"), homedir());
+  });
+
+  it("expands ~/path to a path under the home directory", () => {
+    assert.equal(expandTilde("~/my-claude-projects"), join(homedir(), "my-claude-projects"));
+  });
+
+  it("expands a Windows-style ~\\path", () => {
+    assert.equal(expandTilde("~\\projects"), join(homedir(), "projects"));
+  });
+
+  it("leaves absolute paths untouched", () => {
+    assert.equal(expandTilde("/tmp/projects"), "/tmp/projects");
+  });
+
+  it("leaves relative paths untouched", () => {
+    assert.equal(expandTilde("projects/foo"), "projects/foo");
+  });
+
+  it("does not expand ~ that is not a leading path segment", () => {
+    assert.equal(expandTilde("/opt/~backup"), "/opt/~backup");
+  });
+
+  it("does not expand the ~user form", () => {
+    assert.equal(expandTilde("~alice/projects"), "~alice/projects");
+  });
+});

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,0 +1,25 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Expand a leading `~` in a path to the user's home directory.
+ *
+ * Node's fs APIs do not interpret `~` — the shell normally expands it before
+ * the value reaches the process, but values coming from environment variables
+ * (e.g. `CC_PROJECTS_DIR=~/path`) or config files are passed through verbatim,
+ * which leads to `ENOENT` for `~/...` paths. This helper handles:
+ *
+ *   - `~`            → home directory
+ *   - `~/rest`       → join(home, "rest")   (POSIX)
+ *   - `~\rest`       → join(home, "rest")   (Windows)
+ *
+ * A bare `~user` form (another user's home) is intentionally left untouched
+ * since it cannot be resolved portably.
+ */
+export function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return join(homedir(), p.slice(2));
+  }
+  return p;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,6 @@ export {
   EVENTS_FILE,
 } from "./core/store.js";
 export { extractAllInvocations, extractInvocationsFromFile } from "./core/parser.js";
+export { expandTilde } from "./core/utils.js";
 export { buildStats } from "./cli/format.js";
 export { buildHtmlReport } from "./cli/web-report.js";


### PR DESCRIPTION
## Summary

`CC_PROJECTS_DIR=~/path` のようにチルダを含むパスを設定すると、`scan` が `ENOENT: no such file or directory, scandir '~/my-claude-projects'` で失敗していた問題を修正します。Node の fs API はシェルと違い `~` をホームディレクトリとして解釈しないため、環境変数から渡された `~/...` パスが解決できませんでした。

Closes #178

### 妥当性検証

`src/core/parser.ts` の `getProjectsDir()` を確認し、`process.env["CC_PROJECTS_DIR"]` の値をそのまま `readdir()` に渡していることを確認しました（`~` 展開なし）。`CC_PROJECTS_DIR=~/foo` を指定すると `readdir("~/foo")` が呼ばれ、`~` ディレクトリは実在しないため ENOENT になります。issue の主張どおり現行コードで再現するバグです。

## Changes

- `src/core/utils.ts` を新規追加し、純粋関数 `expandTilde(p)` を実装
  - `~` 単独 → ホームディレクトリ
  - `~/rest`（POSIX）→ `join(home, "rest")`
  - `~\rest`（Windows）→ `join(home, "rest")`
  - 先頭以外の `~` や `~user` 形式（他ユーザーのホーム、可搬的に解決不可）は変更しない
- `src/core/parser.ts` の `getProjectsDir()` で `expandTilde` を適用
- `src/index.ts` から `expandTilde` をエクスポート（`src/core/` のユーティリティとして公開）
- `src/core/utils.test.ts` を追加（7 ケース）し、`package.json` の `test` スクリプトに登録
- `CLAUDE.md` の `CC_PROJECTS_DIR` 説明に `~/` 展開対応を明記

## Test plan

- [x] `npm test` passes（42 tests / うち expandTilde 7 ケース）
- [x] `npm run typecheck` passes
- [x] `npm run lint` は exit 0（既存の warning のみ、新規ファイルはクリーン）

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本変更は影響なし）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kz545HK8GWTuUrnwrPHZg3)_