### PR TITLE
fix: scan --session がファイル名でセッションを絞り込むよう修正

### DIFF
--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { extractInvocationsFromFile } from "./parser.js";
+import { extractInvocationsFromFile, extractAllInvocations } from "./parser.js";
 
 function jsonl(entries: object[]): string {
   return entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
@@ -157,5 +157,59 @@ describe("extractInvocationsFromFile", () => {
     assert.equal(events.length, 1);
     assert.ok(events[0].injectedTokens != null, "injectedTokens should be populated");
     assert.ok((events[0].injectedTokens ?? 0) > 0, "injectedTokens should be positive");
+  });
+});
+
+describe("extractAllInvocations sessionId filtering (#188)", () => {
+  let projectsDir: string;
+  const prev = process.env["CC_PROJECTS_DIR"];
+
+  before(async () => {
+    projectsDir = await mkdtemp(join(tmpdir(), "cc-skill-trace-scan-test-"));
+    process.env["CC_PROJECTS_DIR"] = projectsDir;
+    const proj = join(projectsDir, "some-project");
+    await mkdir(proj, { recursive: true });
+    // Two session files named after their session IDs (Claude Code convention).
+    await writeFile(
+      join(proj, "sess-A.jsonl"),
+      jsonl([userMsg("help A", "2026-01-01T00:00:00.000Z", "sess-A"),
+        assistantSkill("pdf", "2026-01-01T00:00:01.000Z", "sess-A")])
+    );
+    await writeFile(
+      join(proj, "sess-B.jsonl"),
+      jsonl([userMsg("help B", "2026-01-02T00:00:00.000Z", "sess-B"),
+        assistantSkill("docx", "2026-01-02T00:00:01.000Z", "sess-B")])
+    );
+    // A file NOT named after its session ID — exercises the fallback path.
+    await writeFile(
+      join(proj, "renamed.jsonl"),
+      jsonl([userMsg("help C", "2026-01-03T00:00:00.000Z", "sess-C"),
+        assistantSkill("csv", "2026-01-03T00:00:01.000Z", "sess-C")])
+    );
+  });
+
+  after(async () => {
+    if (prev === undefined) delete process.env["CC_PROJECTS_DIR"];
+    else process.env["CC_PROJECTS_DIR"] = prev;
+    await rm(projectsDir, { recursive: true, force: true });
+  });
+
+  it("returns only events for the requested session (fast path by filename)", async () => {
+    const events = await extractAllInvocations({ sessionId: "sess-A" });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].sessionId, "sess-A");
+    assert.equal(events[0].skillName, "pdf");
+  });
+
+  it("returns all sessions when no sessionId filter is given", async () => {
+    const events = await extractAllInvocations();
+    assert.deepEqual(events.map((e) => e.sessionId).sort(), ["sess-A", "sess-B", "sess-C"]);
+  });
+
+  it("falls back to a full scan when no file name matches the sessionId", async () => {
+    const events = await extractAllInvocations({ sessionId: "sess-C" });
+    assert.equal(events.length, 1);
+    assert.equal(events[0].sessionId, "sess-C");
+    assert.equal(events[0].skillName, "csv");
   });
 });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -57,7 +57,7 @@ async function* readJsonlFile(filePath: string): AsyncGenerator<SessionLogEntry>
   }
 }
 
-async function findAllSessionFiles(): Promise<string[]> {
+async function findAllSessionFiles(sessionId?: string): Promise<string[]> {
   const files: string[] = [];
   let projectDirs: string[];
   try {
@@ -72,9 +72,12 @@ async function findAllSessionFiles(): Promise<string[]> {
       if (!s.isDirectory()) continue;
       const sessionFiles = await readdir(projectPath);
       for (const f of sessionFiles) {
-        if (f.endsWith(".jsonl")) {
-          files.push(join(projectPath, f));
-        }
+        if (!f.endsWith(".jsonl")) continue;
+        // Fast path: Claude Code names session files "<sessionId>.jsonl", so when
+        // filtering by session we can skip unrelated files by name instead of
+        // reading and parsing every session file. (#188)
+        if (sessionId && basename(f, ".jsonl") !== sessionId) continue;
+        files.push(join(projectPath, f));
       }
     } catch {
       // skip unreadable dirs
@@ -199,7 +202,13 @@ export async function extractAllInvocations(
     onProgress?: (done: number, total: number) => void;
   } = {}
 ): Promise<SkillInvocationEvent[]> {
-  const files = await findAllSessionFiles();
+  let files = await findAllSessionFiles(opts.sessionId);
+  // Fallback: if a session filter matched no files by name (e.g. Claude Code's
+  // file-naming convention changed), scan everything so the post-read sessionId
+  // filter below can still recover the session. (#188)
+  if (opts.sessionId && files.length === 0) {
+    files = await findAllSessionFiles();
+  }
   const allEvents: SkillInvocationEvent[] = [];
   let done = 0;
 


### PR DESCRIPTION
Closes #188

## 妥当性検証

`src/core/parser.ts` の現行コードを確認し、問題が実在することを確認しました。

- `extractAllInvocations()` は `findAllSessionFiles()` で **全**セッションファイルを列挙し、`extractInvocationsFromFile()` で各ファイルを読み込んだ**後**に `if (opts.sessionId && ev.sessionId !== opts.sessionId) continue;` でフィルタしていました（`parser.ts:202`, `parser.ts:212`）。
- つまり `--session <id>` を指定しても、無関係なセッションファイルを含む全ファイルを読み込んでパースしており、セッション数に比例した不要な IO・メモリ消費が発生します。

## 変更内容

- `findAllSessionFiles(sessionId?)` にオプション引数を追加。Claude Code はセッションファイルを `"<sessionId>.jsonl"` という名前で保存するため、`sessionId` が指定された場合は `basename(f, ".jsonl") !== sessionId` のファイルを**読み込む前に**スキップするようにしました。
- `extractAllInvocations()` から `opts.sessionId` を `findAllSessionFiles()` に渡すよう変更。
- **フォールバック**: 将来 Claude Code のファイル命名規則が変わってファイル名フィルタで 0 件になった場合は、全件スキャンにフォールバックし、従来どおり読み込み後の `ev.sessionId` フィルタで正しいセッションを復旧できるようにしています（正確性を維持）。
- 読み込み後の `ev.sessionId` フィルタは安全網として残しています。

## テスト

`src/core/parser.test.ts` に `extractAllInvocations` のセッションフィルタリングを検証する `describe` ブロックを追加しました（`CC_PROJECTS_DIR` で一時ディレクトリを指定）。

- ファイル名一致による fast path で対象セッションのイベントのみ返す
- `sessionId` 未指定時は全セッションを返す
- ファイル名が sessionId と一致しない場合でも full scan フォールバックで復旧する

### 実行結果

```
npm run typecheck   # 型チェック通過
npm test            # tests 38 / pass 38 / fail 0
npm run lint        # 変更前後で警告数に差分なし (exit 0)
```

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPTXwtsZsinijGHZeaBu37)_