### PR TITLE
fix: vlen が SGR 以外の ANSI シーケンスも除去するよう修正

### DIFF
--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -111,6 +111,21 @@ describe("vlen", () => {
     assert.equal(vlen(colored), 2);
   });
 
+  it("non-SGR CSI sequences are stripped (cursor move / screen clear)", () => {
+    // \x1B[2J (clear screen) and \x1B[1;1H (cursor home) are not SGR ('m')
+    assert.equal(vlen("\x1B[2Jhi\x1B[1;1H"), 2);
+  });
+
+  it("OSC 8 hyperlinks are stripped, leaving only the visible label", () => {
+    // ESC ]8;;URL ST  label  ESC ]8;; ST  → only "label" is visible
+    const link = "\x1B]8;;https://example.com\x1B\\label\x1B]8;;\x1B\\";
+    assert.equal(vlen(link), 5);
+  });
+
+  it("OSC window-title sequences (BEL-terminated) are stripped", () => {
+    assert.equal(vlen("\x1B]0;my title\x07hi"), 2);
+  });
+
   it("mixed ASCII and wide chars", () => {
     assert.equal(vlen("A日B"), 4); // 1 + 2 + 1
   });

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -11,6 +11,21 @@ function W(): number {
 const _segmenter = new Intl.Segmenter();
 
 /**
+ * Match ANSI escape sequences so they can be stripped before measuring width.
+ *
+ * Covers, in order:
+ *  - CSI sequences (`\x1B[…<final>`) — includes SGR colors (`\x1B[32m`) as well
+ *    as cursor moves / screen clears (`\x1B[2J`, `\x1B[1;1H`) that the previous
+ *    SGR-only regex missed.
+ *  - OSC sequences (`\x1B]…`) terminated by BEL (`\x07`) or ST (`\x1B\\`) —
+ *    e.g. OSC 8 hyperlinks and OSC 0 window titles.
+ *  - Other two-byte escapes (`\x1B` + a single Fe byte).
+ */
+// Order matters: OSC (`\x1B]…`) and CSI (`\x1B[…`) are matched before the
+// generic two-byte-escape branch, whose char class also contains `]`/`[`.
+const ANSI_RE = /\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~]|[@-Z\\-_])/g;
+
+/**
  * Visual (terminal column) length of a string.
  *
  * Uses Intl.Segmenter so that each ZWJ sequence (👨‍👩‍👧), variation-selector
@@ -19,7 +34,7 @@ const _segmenter = new Intl.Segmenter();
  * ANSI escape sequences are stripped before measuring.
  */
 export function vlen(s: string): number {
-  const plain = s.replace(/\x1B\[[0-9;]*m/g, "");
+  const plain = s.replace(ANSI_RE, "");
   let len = 0;
   for (const { segment } of _segmenter.segment(plain)) {
     const cp = segment.codePointAt(0) ?? 0;


### PR DESCRIPTION
Closes #189

## Summary

`format.ts` の `vlen()`（ターミナル列幅計算）は、ANSI 除去正規表現 `/\x1B\[[0-9;]*m/g` が **CSI + SGR（色・スタイル）のみ**に対応していた。そのため以下のシーケンスがそのまま文字としてカウントされ、`padRight()` のパディングがずれてダッシュボードの列揃えが崩れる不具合があった。

## 妥当性検証

- `src/cli/format.ts:22` の実装を確認し、正規表現が `...m` で終わる SGR シーケンスしか除去しないことを確認。
- 非 SGR の CSI（`\x1B[2J`, `\x1B[1;1H`）や OSC（`\x1B]8;;URL\x1B\\`、`\x1B]0;title\x07`）を含む入力で `vlen()` がエスケープバイトを数えてしまうことを、追加テスト（修正前は失敗）で再現・確認した。
- `vlen()` は純粋関数で `format.test.ts` が既に `npm test` に組み込まれているため、回帰テストとして最適。

## Changes

- `vlen()` の除去正規表現を、CSI・OSC（BEL / ST 終端）・2バイトエスケープを網羅する `ANSI_RE` に置き換え。
  - 併せて SGR も引き続き除去されるため既存挙動は後方互換。
  - **照合順序**に注意: OSC / CSI を汎用 2バイトエスケープ分岐より先に置いている。汎用分岐の文字クラス `[@-Z\\-_]` は `]`(0x5D) を含むため、順序を誤ると `\x1B]…` の OSC が単独エスケープとして誤って消費される（実装中に実際に踏んだためコメントで明記）。
- `format.test.ts` に非 SGR CSI / OSC 8 ハイパーリンク / OSC ウィンドウタイトルの回帰テストを追加。

## Test plan

- [x] `npm test` passes（38 tests, 全 pass）
- [x] `npm run typecheck` passes
- [x] `npm run lint`（Biome）exit 0
- [x] Manually tested: 追加した 3 テストが修正前は失敗し、修正後に pass することを確認

## Checklist

- [x] No new external runtime dependencies added（正規表現のみ、`strip-ansi` などは不採用）
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（当該パスは未変更）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ未変更）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSzeR5T2BJwNvFmF6rL5fB)_