### PR TITLE
fix: normalize line endings when comparing bundled/installed SKILL.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/skill-md.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
+import { normalizeSkillMd, skillMdChanged } from "./skill-md.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -134,7 +135,7 @@ async function isSkillMdStale(): Promise<boolean> {
       readFile(installedSkillMdPath, "utf-8"),
       readFile(await bundledSkillMdPath(), "utf-8"),
     ]);
-    return installed !== bundled;
+    return skillMdChanged(installed, bundled);
   } catch {
     return false;
   }
@@ -182,11 +183,13 @@ program
       const bundled = await readFile(skillSrc, "utf-8");
       const installed = await readFile(installedSkillMdPath, "utf-8").catch(() => null);
       await mkdir(skillDir, { recursive: true });
-      await fsCopyFile(skillSrc, installedSkillMdPath);
+      // Write with LF-normalized content so a Windows CRLF checkout of the bundled
+      // file doesn't leave the installed copy looking permanently stale (#181).
+      await writeFile(installedSkillMdPath, normalizeSkillMd(bundled), "utf-8");
       if (installed === null) {
         console.log(chalk.green("✓  Skill installed   → " + skillDir));
         console.log(chalk.gray("  Use /skill-trace inside Claude Code to open the dashboard."));
-      } else if (installed !== bundled) {
+      } else if (skillMdChanged(installed, bundled)) {
         console.log(chalk.green("✓  SKILL.md updated  → " + skillDir));
         console.log(chalk.gray("  Restart Claude Code to apply the updated skill definition."));
       } else {

--- a/src/cli/skill-md.test.ts
+++ b/src/cli/skill-md.test.ts
@@ -1,0 +1,28 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { normalizeSkillMd, skillMdChanged } from "./skill-md.js";
+
+test("normalizeSkillMd converts CRLF to LF", () => {
+  assert.equal(normalizeSkillMd("a\r\nb\r\nc"), "a\nb\nc");
+});
+
+test("normalizeSkillMd converts lone CR to LF", () => {
+  assert.equal(normalizeSkillMd("a\rb"), "a\nb");
+});
+
+test("normalizeSkillMd leaves LF-only content unchanged", () => {
+  assert.equal(normalizeSkillMd("a\nb\nc"), "a\nb\nc");
+});
+
+test("skillMdChanged treats CRLF and LF versions as equal (#181)", () => {
+  const lf = "# Skill\nline 1\nline 2\n";
+  const crlf = "# Skill\r\nline 1\r\nline 2\r\n";
+  assert.equal(skillMdChanged(crlf, lf), false);
+  assert.equal(skillMdChanged(lf, lf), false);
+});
+
+test("skillMdChanged detects real content differences", () => {
+  const a = "# Skill\nold\n";
+  const b = "# Skill\nnew\n";
+  assert.equal(skillMdChanged(a, b), true);
+});

--- a/src/cli/skill-md.ts
+++ b/src/cli/skill-md.ts
@@ -1,0 +1,16 @@
+// Line-ending helpers for comparing / writing the bundled vs installed SKILL.md.
+//
+// On Windows with `git config core.autocrlf true`, a checked-out SKILL.md may use
+// CRLF (`\r\n`) while the bundled copy uses LF (`\n`). A byte-exact comparison then
+// reports the installed file as "stale" forever, so `install` overwrites it on every
+// run even though the content is identical (#181).
+
+/** Normalize CRLF / lone-CR line endings to LF for content comparison. */
+export function normalizeSkillMd(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/** True when installed and bundled SKILL.md differ ignoring line-ending style. */
+export function skillMdChanged(installed: string, bundled: string): boolean {
+  return normalizeSkillMd(installed) !== normalizeSkillMd(bundled);
+}


### PR DESCRIPTION
## Summary

Closes #181

On Windows with `git config core.autocrlf true`, a checked-out `SKILL.md` uses CRLF (`\r\n`) while the bundled/expected copy uses LF (`\n`). `isSkillMdStale()` (`src/cli/index.ts`) and the `install` command compared the two files **byte-for-byte**, so the installed copy never matched the bundle. As a result `install` reported the skill as outdated and rewrote it on **every** run (`✓ SKILL.md updated` forever), and `show` warned that the skill was stale even when the content was identical.

### 妥当性検証

- Confirmed `isSkillMdStale()` uses `installed !== bundled` (byte-exact) at `src/cli/index.ts:137`.
- Confirmed the `install` action uses the same byte-exact `installed !== bundled` to decide between the "updated" and "already up to date" messages (`src/cli/index.ts:189`), and copied the bundled file verbatim via `copyFile`, preserving any CRLF.
- A CRLF vs LF copy of the same content therefore always compares as different → permanent false "stale" detection. Reproducible in a unit test (see `skillMdChanged` treating CRLF ≡ LF).

## Changes

- Add `src/cli/skill-md.ts` with `normalizeSkillMd()` (CRLF and lone-CR → LF) and `skillMdChanged()` helpers.
- Use `skillMdChanged()` for both comparisons in `src/cli/index.ts` (`isSkillMdStale()` and the install status message).
- Write the installed `SKILL.md` with LF-normalized content instead of a verbatim `copyFile`, so a CRLF checkout of the bundle never leaves the installed copy looking stale.
- Add `src/cli/skill-md.test.ts` covering CRLF/CR/LF normalization and the CRLF≡LF equivalence, and register it in the `test` script.

## Test plan

- [x] `npm test` passes (40 tests, incl. 5 new)
- [x] `npm run typecheck` passes
- [x] Manually verified: `skillMdChanged(crlf, lf) === false` for identical content; `true` for real content differences.

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code (untouched)
- [x] `SkillInvocationEvent` schema remains backwards-compatible (untouched)

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgDbdBdZDhN1eaZH4nVxxR)_