### PR TITLE
fix: writeSettingsAtomic が rename 失敗時に .tmp ファイルを残さないよう修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/atomic-write.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/atomic-write.test.ts
+++ b/src/cli/atomic-write.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, readFile, writeFile, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeSettingsAtomic } from "./atomic-write.js";
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("writeSettingsAtomic", () => {
+  let dir: string;
+
+  before(async () => {
+    dir = await mkdtemp(join(tmpdir(), "cc-skill-trace-atomic-test-"));
+  });
+
+  after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes JSON to the target path and leaves no tmp file", async () => {
+    const target = join(dir, "settings.json");
+    await writeSettingsAtomic(target, { hooks: { PreToolUse: [] } });
+
+    const written = JSON.parse(await readFile(target, "utf-8"));
+    assert.deepEqual(written, { hooks: { PreToolUse: [] } });
+    assert.equal(await exists(target + ".tmp"), false);
+  });
+
+  it("backs up the previous file as <path>.bak", async () => {
+    const target = join(dir, "backup.json");
+    await writeFile(target, JSON.stringify({ version: 1 }), "utf-8");
+    await writeSettingsAtomic(target, { version: 2 });
+
+    assert.deepEqual(JSON.parse(await readFile(target, "utf-8")), { version: 2 });
+    assert.deepEqual(JSON.parse(await readFile(target + ".bak", "utf-8")), { version: 1 });
+  });
+
+  it("removes the leftover tmp file when rename fails (#184)", async () => {
+    // Make the target an existing directory so rename(tmp, path) fails.
+    const target = join(dir, "as-a-dir");
+    await mkdir(target);
+
+    await assert.rejects(() => writeSettingsAtomic(target, { some: "data" }));
+
+    // The tmp file must not be left behind after the failed rename.
+    assert.equal(await exists(target + ".tmp"), false);
+  });
+});

--- a/src/cli/atomic-write.ts
+++ b/src/cli/atomic-write.ts
@@ -1,0 +1,34 @@
+import { writeFile, rename, copyFile as fsCopyFile, rm } from "node:fs/promises";
+
+/**
+ * Atomically write JSON to `path`:
+ *  1. Back up the current file as `<path>.bak` (best-effort)
+ *  2. Write new content to `<path>.tmp`
+ *  3. Rename tmp → path  (atomic on POSIX; best-effort on Windows)
+ *
+ * If the rename fails (disk full, cross-device move, permission error, …) the
+ * leftover `<path>.tmp` is removed before the error is re-thrown, so stale tmp
+ * files do not accumulate on the filesystem. (#184)
+ */
+export async function writeSettingsAtomic(path: string, data: unknown): Promise<void> {
+  const json = JSON.stringify(data, null, 2);
+  const tmp = path + ".tmp";
+  // Best-effort backup — don't fail if the original doesn't exist yet
+  try {
+    await fsCopyFile(path, path + ".bak");
+  } catch {
+    /* no original yet */
+  }
+  await writeFile(tmp, json, "utf-8");
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    // Clean up the leftover tmp file before re-throwing (#184)
+    try {
+      await rm(tmp, { force: true });
+    } catch {
+      /* best effort */
+    }
+    throw err;
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@ if (_nodeMajor < 18) {
 
 import { program } from "commander";
 import chalk from "chalk";
-import { readFile, writeFile, rename, copyFile as fsCopyFile } from "node:fs/promises";
+import { readFile, writeFile, copyFile as fsCopyFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -21,6 +21,7 @@ import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
+import { writeSettingsAtomic } from "./atomic-write.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -54,25 +55,6 @@ function validateDateRange(since: string | undefined, before: string | undefined
     console.error(chalk.red(`✗  --since (${since}) must be earlier than --before (${before})`));
     process.exit(1);
   }
-}
-
-/**
- * Atomically write JSON to `path`:
- *  1. Back up the current file as `<path>.bak` (best-effort)
- *  2. Write new content to `<path>.tmp`
- *  3. Rename tmp → path  (atomic on POSIX; best-effort on Windows)
- */
-async function writeSettingsAtomic(path: string, data: unknown): Promise<void> {
-  const json = JSON.stringify(data, null, 2);
-  const tmp = path + ".tmp";
-  // Best-effort backup — don't fail if the original doesn't exist yet
-  try {
-    await fsCopyFile(path, path + ".bak");
-  } catch {
-    /* no original yet */
-  }
-  await writeFile(tmp, json, "utf-8");
-  await rename(tmp, path);
 }
 
 function scanProgress(done: number, total: number): void {


### PR DESCRIPTION
## Summary

`writeSettingsAtomic`（`install` / `uninstall` が `~/.claude/settings.json` を書き込む際に使用）は `writeFile(tmp)` → `rename(tmp, path)` の順でアトミック書き込みを行うが、`rename()` が失敗した場合（ディスクフル・クロスデバイス移動・権限エラー等）に `<path>.tmp` がファイルシステムに残り続けていた。以降の `install` / `uninstall` のたびに新しい `.tmp` を作るが古いものは掃除されず、古い設定内容を含む `.tmp` がユーザーの混乱を招く。

Closes #184

### 妥当性検証

`src/cli/index.ts:75` の `await rename(tmp, path);` に失敗時のクリーンアップが無いことを現行コードで確認。`rename` はここでのみ使用されている。実際に、対象パスが既存ディレクトリで rename が失敗するケースを再現するテストを追加し、修正前は `.tmp` が残ることを確認した。

## Changes

- `writeSettingsAtomic` を `src/cli/index.ts` から `src/cli/atomic-write.ts` に切り出し（`program.parse()` を伴う CLI エントリを import せずに単体テストできるようにするため）。
- `rename(tmp, path)` を `try/catch` で囲み、失敗時は best-effort で `rm(tmp, { force: true })` してから元のエラーを再スローするよう修正。
- `src/cli/index.ts` の未使用になった `rename` import を削除。
- 回帰テスト `src/cli/atomic-write.test.ts` を追加し、`package.json` の `test` スクリプトに登録。
  - 正常書き込みで tmp が残らないこと
  - 既存ファイルが `<path>.bak` にバックアップされること
  - rename 失敗時に `<path>.tmp` が削除されエラーが再スローされること（#184）

外部ランタイム依存の追加なし。`hook-capture` パスおよび `SkillInvocationEvent` スキーマには変更なし。

## Test plan

- [x] `npm test` passes（38 tests, 0 fail — 新規 3 件含む）
- [x] `npm run typecheck` passes
- [x] Manually tested: 対象パスを既存ディレクトリにして rename を失敗させ、修正前は `.tmp` が残存、修正後は削除されエラーが再スローされることをテストで確認

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本 PR は非該当・変更なし）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_0171GdRFzEAj6EJEVRqecyBW)_