### PR TITLE
fix: build が SKILL.md を dist/ にコピーしないため install が常に失敗する問題を修正 (#183)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,14 +41,14 @@
     "src/skill/SKILL.md"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-skill.mjs",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint src",
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/copy-skill.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/scripts/copy-skill.mjs
+++ b/scripts/copy-skill.mjs
@@ -1,0 +1,33 @@
+// Copies the bundled SKILL.md into dist/ after `tsc`, because tsc only emits
+// .js/.d.ts and never copies .md assets. Without this step dist/skill/SKILL.md
+// is missing and `cc-skill-trace install` prints "Skill file not found" even
+// after a successful `npm install`. (#183)
+//
+// Kept as a plain cross-platform Node script (no `cp`) so the build works on
+// Windows CI as well as macOS/Linux.
+
+import { mkdir, copyFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Copy src/skill/SKILL.md → dist/skill/SKILL.md under the given project root.
+ * Returns the destination path.
+ */
+export async function copySkillMd(rootDir) {
+  const root = rootDir ?? join(dirname(fileURLToPath(import.meta.url)), "..");
+  const src = join(root, "src", "skill", "SKILL.md");
+  const destDir = join(root, "dist", "skill");
+  const dest = join(destDir, "SKILL.md");
+  await mkdir(destDir, { recursive: true });
+  await copyFile(src, dest);
+  return dest;
+}
+
+// Run the copy when invoked directly (i.e. `node scripts/copy-skill.mjs`).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  copySkillMd().catch((err) => {
+    console.error(`copy-skill: failed to copy SKILL.md — ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/src/cli/copy-skill.test.ts
+++ b/src/cli/copy-skill.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, readFile, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+// @ts-expect-error - plain .mjs build helper, no type declarations
+import { copySkillMd } from "../../scripts/copy-skill.mjs";
+
+// Regression test for #183: `tsc` never copies .md assets, so the build must
+// place src/skill/SKILL.md at dist/skill/SKILL.md or `install` fails with
+// "Skill file not found".
+describe("copySkillMd (#183)", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "cc-skill-trace-copy-test-"));
+    await mkdir(join(root, "src", "skill"), { recursive: true });
+    await writeFile(join(root, "src", "skill", "SKILL.md"), "# SKILL\ncontent\n", "utf-8");
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("creates dist/skill/SKILL.md with identical content", async () => {
+    const dest = await copySkillMd(root);
+    assert.equal(dest, join(root, "dist", "skill", "SKILL.md"));
+    await access(dest); // throws if the file was not created
+    const copied = await readFile(dest, "utf-8");
+    const original = await readFile(join(root, "src", "skill", "SKILL.md"), "utf-8");
+    assert.equal(copied, original);
+  });
+
+  it("creates the dist/skill directory when it does not exist yet", async () => {
+    await assert.rejects(access(join(root, "dist", "skill")));
+    await copySkillMd(root);
+    await access(join(root, "dist", "skill"));
+  });
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,7 @@ if (_nodeMajor < 18) {
 
 import { program } from "commander";
 import chalk from "chalk";
-import { readFile, writeFile, rename, copyFile as fsCopyFile } from "node:fs/promises";
+import { readFile, writeFile, rename, copyFile as fsCopyFile, access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -122,7 +122,21 @@ async function bundledSkillMdPath(): Promise<string> {
   const { fileURLToPath } = await import("node:url");
   const { dirname } = await import("node:path");
   const here = dirname(fileURLToPath(import.meta.url));
-  return join(here, "..", "skill", "SKILL.md");
+  // Primary: dist/skill/SKILL.md, copied by the build step. Fallback: the source
+  // copy shipped in the package (`files` includes src/skill/SKILL.md), so a
+  // published build that predates the copy step still resolves instead of
+  // failing with "Skill file not found". (#183)
+  const primary = join(here, "..", "skill", "SKILL.md");
+  const fallback = join(here, "..", "..", "src", "skill", "SKILL.md");
+  for (const candidate of [primary, fallback]) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return primary;
 }
 
 const installedSkillMdPath = join(homedir(), ".claude", "skills", "skill-trace", "SKILL.md");


### PR DESCRIPTION
Closes #183

## Summary

`npm run build` (`tsc`) は `.js` / `.d.ts` しか出力せず `.md` をコピーしないため、ビルド後に `dist/skill/SKILL.md` が存在しませんでした。`bundledSkillMdPath()` はこのパスを参照するので、`cc-skill-trace install` が毎回 `Skill file not found` を表示し、`/skill-trace` スラッシュコマンドがインストールされない状態でした。

### 妥当性検証（再現確認）

現行 `main` で問題が実在することを確認しました。

- `npm run build` 実行後、`dist/` には `cli/` `core/` `index.*` のみが生成され、`dist/skill/SKILL.md` は**存在しない**。
- `bundledSkillMdPath()` は `dist/cli/` から `../skill/SKILL.md`（= `dist/skill/SKILL.md`）を返すため、`install` の `readFile(skillSrc)` が `ENOENT` で失敗し `catch` で `Skill file not found` を出力する。
- 併発影響として `isSkillMdStale()`（#190）も bundled ファイルを読めず常に `false` を返す。

修正後、`HOME` を差し替えた一時ディレクトリで `node dist/cli/index.js install` を実行し、`✓ Skill installed` と表示されて `~/.claude/skills/skill-trace/SKILL.md` が配置されることを確認しました。

## Changes

- **`scripts/copy-skill.mjs` を追加**: `src/skill/SKILL.md` → `dist/skill/SKILL.md` をコピーする小さなクロスプラットフォーム Node スクリプト（Windows CI でも動くよう `cp` は使わない）。
- **`package.json` の `build` を更新**: `tsc && node scripts/copy-skill.mjs`。これで `dist/` が自己完結する。`files` の `dist/` が生成物を含むためパッケージにも同梱される。
- **`bundledSkillMdPath()` にフォールバックを追加**: `dist/skill/SKILL.md` が無い場合はパッケージ同梱の `src/skill/SKILL.md`（`files` に含まれる）を参照。コピー手順を含まない既存の公開ビルドでも `install` が失敗しなくなる。
- **回帰テストを追加** (`src/cli/copy-skill.test.ts`): 一時ディレクトリで `copySkillMd()` が `dist/skill/SKILL.md` を同一内容で生成することを検証。`npm test` の対象に追加。

無関係なリファクタや依存追加は行っていません（新規ランタイム依存なし）。

## Test plan

- [x] `npm test` passes（37 件 pass、うち新規 2 件）
- [x] `npm run typecheck` passes
- [x] `npm run build` 後に `dist/skill/SKILL.md` が生成されることを確認
- [x] Manually tested: 一時 `HOME` で `install` を実行し `✓ Skill installed` を確認。`dist/skill` を削除した状態でも `src/skill` フォールバック経由で install 成功を確認
- [x] `biome lint` / `format:check` clean（警告数はベースラインと同じ 9 件）

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本 PR は build/install 経路のみ変更、hook-capture は未変更）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1s9nhuqTHpPgTjzNVKdmv)_