### PR TITLE
fix: back up events.jsonl before scan --clear to prevent data loss (#180)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,14 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
-import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store.js";
+import {
+  readEvents,
+  clearEvents,
+  appendEvent,
+  pruneEvents,
+  backupEvents,
+  EVENTS_FILE,
+} from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
@@ -355,6 +362,15 @@ program
   .action(async (opts) => {
     validateDateRange(opts.since, opts.before);
     if (opts.clear) {
+      // Back up before clearing so a mid-scan failure can't destroy history (#180).
+      const { backupPath, rotatedTo } = await backupEvents();
+      if (backupPath) {
+        if (rotatedTo) {
+          console.log(chalk.gray(`  Previous backup moved to ${rotatedTo}`));
+        }
+        console.log(chalk.gray(`  Backup saved to ${backupPath}`));
+        console.log(chalk.gray(`  To restore: cp ${backupPath} ${EVENTS_FILE}`));
+      }
       await clearEvents();
       console.log(chalk.gray("  Cleared."));
     }

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -4,7 +4,8 @@ import { appendFile } from "node:fs/promises";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { appendEvent, readEvents, clearEvents, pruneEvents } from "./store.js";
+import { readFile } from "node:fs/promises";
+import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents } from "./store.js";
 import type { SkillInvocationEvent } from "./types.js";
 
 function makeEvent(overrides: Partial<SkillInvocationEvent> = {}): SkillInvocationEvent {
@@ -106,6 +107,61 @@ describe("store", () => {
       await clearEvents(dir);
       const events = await readEvents(dir);
       assert.deepEqual(events, []);
+    });
+  });
+
+  describe("backupEvents (#180)", () => {
+    it("returns null backupPath when there is no store file", async () => {
+      const bDir = dir + "-backup-none";
+      const result = await backupEvents(bDir);
+      assert.equal(result.backupPath, null);
+      assert.equal(result.rotatedTo, null);
+    });
+
+    it("copies events.jsonl to events.jsonl.bak", async () => {
+      const bDir = dir + "-backup-basic";
+      await appendEvent(makeEvent({ id: "keep-1" }), bDir);
+      await appendEvent(makeEvent({ id: "keep-2" }), bDir);
+
+      const result = await backupEvents(bDir);
+      assert.equal(result.backupPath, join(bDir, "events.jsonl.bak"));
+      assert.equal(result.rotatedTo, null);
+
+      const original = await readFile(join(bDir, "events.jsonl"), "utf-8");
+      const backup = await readFile(join(bDir, "events.jsonl.bak"), "utf-8");
+      assert.equal(backup, original);
+    });
+
+    it("preserves the store contents even after a subsequent clear", async () => {
+      const bDir = dir + "-backup-then-clear";
+      await appendEvent(makeEvent({ id: "history" }), bDir);
+
+      await backupEvents(bDir);
+      await clearEvents(bDir);
+
+      // Store is empty, but the backup still holds the original event.
+      assert.deepEqual(await readEvents(bDir), []);
+      const backup = await readFile(join(bDir, "events.jsonl.bak"), "utf-8");
+      assert.match(backup, /"id":"history"/);
+    });
+
+    it("rotates an existing backup to .bak.bak instead of overwriting it", async () => {
+      const bDir = dir + "-backup-rotate";
+      await appendEvent(makeEvent({ id: "gen-1" }), bDir);
+      const first = await backupEvents(bDir);
+      assert.equal(first.rotatedTo, null);
+
+      // New state, second backup should rotate the previous one.
+      await appendEvent(makeEvent({ id: "gen-2" }), bDir);
+      const second = await backupEvents(bDir);
+      assert.equal(second.rotatedTo, join(bDir, "events.jsonl.bak.bak"));
+
+      const rotated = await readFile(join(bDir, "events.jsonl.bak.bak"), "utf-8");
+      assert.match(rotated, /"id":"gen-1"/);
+      assert.doesNotMatch(rotated, /"id":"gen-2"/);
+
+      const current = await readFile(join(bDir, "events.jsonl.bak"), "utf-8");
+      assert.match(current, /"id":"gen-2"/);
     });
   });
 

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -114,6 +114,50 @@ export function clearEvents(dir = STORE_DIR): Promise<void> {
   });
 }
 
+export interface BackupResult {
+  /** Absolute path of the newly written backup, or null if there was nothing to back up. */
+  backupPath: string | null;
+  /** If a previous backup already existed, the path it was rotated to; otherwise null. */
+  rotatedTo: string | null;
+}
+
+/**
+ * Copy `events.jsonl` to `events.jsonl.bak` so a destructive operation (e.g.
+ * `scan --clear`) can be recovered if it fails midway (#180). If a backup
+ * already exists it is rotated to `events.jsonl.bak.bak` rather than silently
+ * overwritten. Returns `{ backupPath: null }` when there is nothing to back up.
+ */
+export function backupEvents(dir = STORE_DIR): Promise<BackupResult> {
+  return enqueueWrite(dir, async () => {
+    const eventsPath = join(dir, "events.jsonl");
+    const bakPath = join(dir, "events.jsonl.bak");
+    const bakBakPath = join(dir, "events.jsonl.bak.bak");
+
+    let content: string;
+    try {
+      content = await readFile(eventsPath, "utf-8");
+    } catch {
+      // No store file yet — nothing to back up.
+      return { backupPath: null, rotatedTo: null };
+    }
+
+    await ensureStoreDir(dir);
+
+    // Preserve an existing backup instead of overwriting it.
+    let rotatedTo: string | null = null;
+    try {
+      const prev = await readFile(bakPath, "utf-8");
+      await writeFile(bakBakPath, prev, "utf-8");
+      rotatedTo = bakBakPath;
+    } catch {
+      // No existing backup to rotate.
+    }
+
+    await writeFile(bakPath, content, "utf-8");
+    return { backupPath: bakPath, rotatedTo };
+  });
+}
+
 /** Remove events whose timestamp is older than `beforeIso` (ISO string).
  *  Returns counts of removed and kept events. */
 export function pruneEvents(


### PR DESCRIPTION
Closes #180

## 妥当性検証

`src/cli/index.ts` の現行 `scan` コマンドを確認し、問題が実在することを確認しました。

```ts
if (opts.clear) {
  await clearEvents();          // ← ① 全イベントを削除
  console.log(chalk.gray("  Cleared."));
}
const { events, imported } = await scanAndMerge({ ... });  // ← ② スキャン
```

`clearEvents()`（`src/core/store.ts`）は `events.jsonl` を空文字で上書きします。① の後に ②（`scanAndMerge`）が Ctrl+C・ディスクエラー等で失敗すると、`events.jsonl` は空のままとなり、長期蓄積した履歴が復旧不能になります。issue の再現手順どおりのデータ損失バグです。

## 変更内容

issue の推奨（案2: バックアップ方式）を実装しました。

- **`src/core/store.ts`**: `backupEvents(dir)` を追加。
  - `events.jsonl` を `events.jsonl.bak` にコピーしてから破壊的操作を行えるようにする。
  - 既存のバックアップがある場合は上書きせず `events.jsonl.bak.bak` に退避（ローテーション）。
  - バックアップ対象が無い（ストアファイル未作成）場合は `{ backupPath: null }` を返す。
  - 他の書き込み操作と同じ `enqueueWrite` キューで直列化し、並行 append と競合しない。
- **`src/cli/index.ts`**: `scan --clear` が `clearEvents()` の前に `backupEvents()` を呼ぶよう変更。バックアップパスと復元コマンド（`cp <bak> <events.jsonl>`）、ローテーション先を通知する。

Acceptance criteria との対応:

- [x] `scan --clear` 実行前に `events.jsonl.bak` を作成する
- [x] スキャン成功後にバックアップの削除は行わない（手動管理）
- [x] バックアップパスをユーザーに通知する
- [x] バックアップが既に存在する場合は `.bak.bak` に退避
- [ ] `doctor --check-store`（#175）でバックアップの存在を通知する → #175 未実装のため対象外（本 issue の最小修正の範囲外）

## テスト

`src/core/store.test.ts` に `backupEvents` のテストを追加（ストアなし時の null 返却 / `.bak` へのコピー / clear 後もバックアップが残ること / 既存バックアップの `.bak.bak` ローテーション）。

- `npm run typecheck` ✅
- `npm run lint` ✅ (exit 0)
- `npm run format:check` ✅
- `npm run build` ✅
- `npm test` ✅ 44 passed / 0 failed

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZnKwjqru39Y4LEZtLRkeS)_