### PR TITLE
fix: show --follow の tick が重複実行され出力が壊れる問題を修正 (#186)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/follow.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/follow.test.ts
+++ b/src/cli/follow.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { skipWhileRunning } from "./follow.js";
+
+describe("skipWhileRunning", () => {
+  it("skips calls that arrive while a previous call is still in-flight", async () => {
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const guarded = skipWhileRunning(async () => {
+      calls++;
+      await gate; // stay in-flight until released
+    });
+
+    const first = guarded(); // starts running, blocks on `gate`
+    await guarded(); // fires mid-run → must be skipped
+    await guarded(); // still mid-run → must be skipped
+    assert.equal(calls, 1, "concurrent ticks should be dropped");
+
+    release();
+    await first;
+
+    await guarded(); // previous call finished → runs again
+    assert.equal(calls, 2);
+  });
+
+  it("resets the guard even when the wrapped function throws", async () => {
+    let calls = 0;
+    const guarded = skipWhileRunning(async () => {
+      calls++;
+      throw new Error("boom");
+    });
+
+    await assert.rejects(guarded(), /boom/);
+    await assert.rejects(guarded(), /boom/);
+    assert.equal(calls, 2, "guard must reset after a rejection");
+  });
+
+  it("allows sequential (non-overlapping) calls to run every time", async () => {
+    let calls = 0;
+    const guarded = skipWhileRunning(async () => {
+      calls++;
+    });
+
+    await guarded();
+    await guarded();
+    await guarded();
+    assert.equal(calls, 3);
+  });
+});

--- a/src/cli/follow.ts
+++ b/src/cli/follow.ts
@@ -1,0 +1,27 @@
+// Helpers for the `show --follow` live-tail loop.
+
+/**
+ * Wrap an async function so that overlapping invocations are skipped.
+ *
+ * While a call is still in-flight, any further calls return immediately
+ * without invoking `fn` again. `setInterval` ignores the promise returned
+ * by its callback, so a `tick` that takes longer than the interval would
+ * otherwise start running concurrently with the next one — interleaving
+ * `stdout` writes (screen clears + dashboard renders) and producing
+ * flickering / garbled output. Guarding the callback keeps at most one
+ * `tick` running at a time; ticks that fire mid-render are simply dropped.
+ *
+ * See https://github.com/revo1290/cc-skill-trace/issues/186
+ */
+export function skipWhileRunning(fn: () => Promise<void>): () => Promise<void> {
+  let running = false;
+  return async () => {
+    if (running) return;
+    running = true;
+    try {
+      await fn();
+    } finally {
+      running = false;
+    }
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import { readEvents, clearEvents, appendEvent, pruneEvents } from "../core/store
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
+import { skipWhileRunning } from "./follow.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -332,8 +333,13 @@ program
             "  \r"
         );
       };
-      await tick();
-      const interval = setInterval(tick, 2000);
+      // Guard against overlapping ticks: if a tick takes longer than the
+      // interval (large events.jsonl / slow FS), setInterval would otherwise
+      // start the next one before the previous finished, interleaving stdout
+      // writes and garbling the output (#186).
+      const guardedTick = skipWhileRunning(tick);
+      await guardedTick();
+      const interval = setInterval(guardedTick, 2000);
       const cleanup = () => {
         clearInterval(interval);
         process.stdout.write("\n");


### PR DESCRIPTION
Closes #186

## 妥当性検証

`src/cli/index.ts` の `show --follow` 実装を確認し、issue の主張がそのまま現行コードで成立することを確認した：

```ts
await tick();
const interval = setInterval(tick, 2000);   // ← tick の返す Promise を await しない
```

`setInterval` はコールバックの戻り値（Promise）を無視するため、`tick` が 2 秒以内に完了しない場合（`events.jsonl` が数千イベント規模、または FS が遅い場合）、**前の tick がまだ実行中でも次の tick が並行起動する**。`tick` は `process.stdout.write("\x1B[2J\x1B[0f")`（画面クリア）とダッシュボード描画を行うため、複数の tick が交錯すると画面のちらつき・garbled 出力が発生する。再入を防ぐガードが存在しないことを確認した。

## 変更内容

- `src/cli/follow.ts` を新規追加し、再入ガード `skipWhileRunning()` を実装。実行中に到達した呼び出しは `fn` を呼ばずに即 return し、常に 1 つの tick だけが走るようにする（`finally` で確実にフラグを解除するため、例外時もガードがリセットされる）。
- `src/cli/index.ts` の `--follow` ループで `tick` を `skipWhileRunning(tick)` でラップして使用。挙動を変えるのはこの 1 箇所のみで、他コマンドには影響しない。

これは issue の「完全な修正: tick の実行中は次の tick をスキップするフラグを追加する」に沿った最小変更。

## テスト

`src/cli/follow.test.ts` を追加：

- in-flight 中に到達した呼び出しがスキップされること
- ラップ対象が例外を投げてもガードがリセットされ次回以降呼び出されること
- 逐次（非重複）呼び出しは毎回実行されること

```
npm run typecheck   # ✓ パス
npm test            # ✓ 38 tests pass (既存 35 + 新規 3)
npm run lint        # ✓ exit 0（新規ファイルに診断なし）
```

---
🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_014xkZHqmgwePUSoU2VSGy3A)_