### PR TITLE
fix: scan が非 Claude セッションの .jsonl を処理しないよう検証を追加する

### DIFF
--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { extractInvocationsFromFile } from "./parser.js";
+import { extractInvocationsFromFile, isClaudeSessionFile } from "./parser.js";
 
 function jsonl(entries: object[]): string {
   return entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
@@ -127,6 +127,27 @@ describe("extractInvocationsFromFile", () => {
     const events = await extractInvocationsFromFile(file);
     assert.equal(events.length, 1);
     assert.ok((events[0].triggerMessage?.length ?? 0) <= 300);
+  });
+
+  it("skips non-Claude JSONL files that happen to live under the scan dir (#171)", async () => {
+    const file = join(dir, "analytics.jsonl");
+    // A user's own JSONL data set — valid JSON, but not a Claude session log.
+    await writeFile(file, jsonl([
+      { event: "pageview", url: "/home", ts: 123 },
+      { event: "click", target: "button", ts: 124 },
+    ]));
+    const events = await extractInvocationsFromFile(file);
+    assert.equal(events.length, 0);
+  });
+
+  it("isClaudeSessionFile detects session logs and rejects unrelated JSONL (#171)", async () => {
+    const sessionFile = join(dir, "detect-session.jsonl");
+    await writeFile(sessionFile, jsonl([userMsg("hi"), assistantSkill("pdf")]));
+    assert.equal(await isClaudeSessionFile(sessionFile), true);
+
+    const otherFile = join(dir, "detect-other.jsonl");
+    await writeFile(otherFile, jsonl([{ event: "pageview", url: "/home" }]));
+    assert.equal(await isClaudeSessionFile(otherFile), false);
   });
 
   it("populates injectedTokens from the following tool_result content (#34)", async () => {

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -41,6 +41,53 @@ async function mapWithLimit<T, R>(
 
 // ─── JSONL file helpers ──────────────────────────────────────────────────────
 
+// Entry `type` values used by Claude Code session logs. Kept permissive so a
+// format change on the upstream side degrades gracefully rather than dropping
+// every file.
+const CLAUDE_ENTRY_TYPES = new Set([
+  "message",
+  "tool_result",
+  "summary",
+  "user",
+  "assistant",
+  "system",
+]);
+
+/**
+ * Cheap heuristic that a `.jsonl` file is actually a Claude Code session log.
+ * Only the first few non-empty lines are inspected, so unrelated JSONL files
+ * that happen to live under `CC_PROJECTS_DIR` are skipped without being fully
+ * read or mis-parsed as skill invocations (#171).
+ */
+export async function isClaudeSessionFile(filePath: string): Promise<boolean> {
+  const stream = createReadStream(filePath, { encoding: "utf-8" });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  try {
+    let checked = 0;
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      if (++checked > 5) break;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue; // tolerate a malformed leading line
+      }
+      if (!parsed || typeof parsed !== "object") continue;
+      const obj = parsed as Record<string, unknown>;
+      if (typeof obj["sessionId"] === "string") return true;
+      if (typeof obj["type"] === "string" && CLAUDE_ENTRY_TYPES.has(obj["type"])) return true;
+      const message = obj["message"];
+      if (message && typeof message === "object" && "role" in message) return true;
+    }
+    return false;
+  } finally {
+    rl.close();
+    stream.destroy();
+  }
+}
+
 async function* readJsonlFile(filePath: string): AsyncGenerator<SessionLogEntry> {
   const rl = createInterface({
     input: createReadStream(filePath, { encoding: "utf-8" }),
@@ -94,6 +141,16 @@ export async function extractInvocationsFromFile(
   filePath: string
 ): Promise<SkillInvocationEvent[]> {
   const events: SkillInvocationEvent[] = [];
+
+  // Skip files that are not Claude Code session logs so a stray `.jsonl`
+  // under CC_PROJECTS_DIR is not parsed as skill invocations (#171).
+  if (!(await isClaudeSessionFile(filePath))) {
+    if (process.env["CC_DEBUG"]) {
+      process.stderr.write(`[cc-skill-trace] skipping non-session file: ${filePath}\n`);
+    }
+    return events;
+  }
+
   const entries: SessionLogEntry[] = [];
 
   for await (const entry of readJsonlFile(filePath)) {


### PR DESCRIPTION
## Summary

`src/core/parser.ts` は `CC_PROJECTS_DIR` 配下のすべての `.jsonl` を無検証で処理していたため、ユーザーが `CC_PROJECTS_DIR` を独自ディレクトリに向けた場合や、他ツールが `~/.claude/projects/` に `.jsonl` を置いた場合に、Claude Code セッションログではないファイルまで解析対象になっていました。

このPRは、対象ファイルが Claude Code のセッションログかどうかを **先頭数行だけ** で判定し、そうでなければスキップするようにします。

Closes #171

## 妥当性検証で確認した内容

- `findAllSessionFiles()` は拡張子が `.jsonl` であるかだけを見てファイルを収集しており、`extractInvocationsFromFile()` も内容検証なしにパースしていた（`src/core/parser.ts:75`, `src/core/parser.ts:93`）。
- 非 Claude の JSONL（例: 独自の analytics データ）が `CC_PROJECTS_DIR` 配下にあると、無関係なファイルを読み込んでしまうことを確認。現行コードで再現する構造上の問題であることを確認した。

## Changes

- `isClaudeSessionFile(filePath)` を追加。先頭の非空行（最大5行）だけを読み、`sessionId` の存在・既知の `type`（message/tool_result/summary/user/assistant/system）・`message.role` のいずれかを持つかで判定する。フォーマット変更に対して過度に脆くならないよう許容的に判定。
- `extractInvocationsFromFile()` の先頭でこの判定を行い、非セッションファイルはスキップ。`CC_DEBUG=1` のときのみ stderr に警告を出力する。
- 正規のセッションファイルはこれまで通り処理される（判定は先頭数行の読み込みのみで、体感速度に影響しない）。
- テストを追加: 非 Claude JSONL がスキップされること、`isClaudeSessionFile` がセッションログを検出し無関係な JSONL を拒否すること。

## Test plan

- [x] `npm test` passes（42 tests, 0 fail）
- [x] `npm run typecheck` passes
- [x] `npm run lint` はエラーなし（exit 0、新規 warning なし）
- [x] Manually tested: 非 Claude JSONL / セッションログ双方に対する挙動を新規テストで検証

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本変更は scan/parser のみ、hook-capture パスは不変）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_016zJN1JugyaUQvL4Fqa6kWD)_