### PR TITLE
fix: install/uninstall のフック検出を command フィールド一致に変更 (#187)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/cli/hooks.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/hooks.test.ts
+++ b/src/cli/hooks.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isCcSkillTraceHook, CC_HOOK_COMMAND } from "./hooks.js";
+
+describe("isCcSkillTraceHook", () => {
+  it("matches the hook entry install registers", () => {
+    const entry = {
+      matcher: "Skill",
+      hooks: [{ type: "command", command: CC_HOOK_COMMAND }],
+    };
+    assert.equal(isCcSkillTraceHook(entry), true);
+  });
+
+  it("matches when the command is wrapped (e.g. absolute path or npx)", () => {
+    const entry = {
+      matcher: "Skill",
+      hooks: [{ type: "command", command: "npx cc-skill-trace hook-capture" }],
+    };
+    assert.equal(isCcSkillTraceHook(entry), true);
+  });
+
+  it("does NOT match an unrelated hook that only mentions cc-skill-trace in a field", () => {
+    // Regression for #187: JSON.stringify(h).includes("cc-skill-trace") wrongly
+    // matched this because the string appears in the description, not the command.
+    const entry = {
+      matcher: "Bash",
+      description: "Used alongside cc-skill-trace for debugging",
+      hooks: [{ type: "command", command: "my-other-tool" }],
+    };
+    assert.equal(isCcSkillTraceHook(entry), false);
+  });
+
+  it("does not match an unrelated hook with no cc-skill-trace reference", () => {
+    const entry = {
+      matcher: "Skill",
+      hooks: [{ type: "command", command: "some-other-capture-tool" }],
+    };
+    assert.equal(isCcSkillTraceHook(entry), false);
+  });
+
+  it("is safe on malformed / non-object entries", () => {
+    assert.equal(isCcSkillTraceHook(null), false);
+    assert.equal(isCcSkillTraceHook(undefined), false);
+    assert.equal(isCcSkillTraceHook("cc-skill-trace hook-capture"), false);
+    assert.equal(isCcSkillTraceHook({}), false);
+    assert.equal(isCcSkillTraceHook({ hooks: "not-an-array" }), false);
+    assert.equal(isCcSkillTraceHook({ hooks: [null, 42, {}] }), false);
+  });
+});

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -1,0 +1,27 @@
+// Detection of cc-skill-trace's own PreToolUse hook entry inside a
+// Claude Code settings.json. Kept in its own module so it can be unit-tested
+// without importing the CLI entrypoint (which runs `program.parse()` on load).
+
+/** The command string cc-skill-trace registers as its PreToolUse hook. */
+export const CC_HOOK_COMMAND = "cc-skill-trace hook-capture";
+
+/**
+ * Detect whether a PreToolUse hook entry is the cc-skill-trace capture hook.
+ *
+ * We inspect the nested `hooks[].command` fields directly instead of doing a
+ * substring search over the whole serialized entry. A serialized-object search
+ * (`JSON.stringify(h).includes("cc-skill-trace")`) matches any hook that merely
+ * mentions the string anywhere — e.g. in an unrelated hook's `description` —
+ * causing `install` to skip registration and `uninstall` to delete the wrong
+ * hook. Matching the command field avoids both. (#187)
+ */
+export function isCcSkillTraceHook(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const hooks = (entry as { hooks?: unknown }).hooks;
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((hk) => {
+    if (!hk || typeof hk !== "object") return false;
+    const command = (hk as { command?: unknown }).command;
+    return typeof command === "string" && command.includes(CC_HOOK_COMMAND);
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,6 +29,7 @@ import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
 import { parseDuration } from "./duration.js";
+import { isCcSkillTraceHook } from "./hooks.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -154,7 +155,7 @@ program
     const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
     const preToolUse = (hooks.PreToolUse ?? []) as Array<Record<string, unknown>>;
 
-    if (preToolUse.some((h) => JSON.stringify(h).includes("cc-skill-trace"))) {
+    if (preToolUse.some(isCcSkillTraceHook)) {
       console.log(chalk.gray("  Hook already registered → " + settingsPath));
     } else {
       preToolUse.push({
@@ -616,7 +617,7 @@ program
 
     const hooks = (settings.hooks ?? {}) as Record<string, unknown[]>;
     const preToolUse = (hooks.PreToolUse ?? []) as Array<Record<string, unknown>>;
-    const filtered = preToolUse.filter((h) => !JSON.stringify(h).includes("cc-skill-trace"));
+    const filtered = preToolUse.filter((h) => !isCcSkillTraceHook(h));
 
     if (filtered.length === preToolUse.length) {
       console.log(chalk.yellow("⚠  Hook not found in: " + settingsPath));


### PR DESCRIPTION
Closes #187

## Summary

`install` / `uninstall` の登録済みフック検出が `JSON.stringify(h).includes("cc-skill-trace")` に依存しており、シリアライズしたフックオブジェクト全体を文字列検索していた。そのため、`description` など無関係なフィールドに `"cc-skill-trace"` という文字列が含まれるだけで誤検知していた。

- **install**: 実際には cc-skill-trace のフックが未登録でも「Hook already registered」と誤判定し、フックが登録されない。
- **uninstall**: `"cc-skill-trace"` を含むすべてのフックを削除するため、無関係なフックを巻き添えで削除する。

### 妥当性検証

現行コードを確認し、問題が実在することを確認した:

- `src/cli/index.ts:157`（install）: `preToolUse.some((h) => JSON.stringify(h).includes("cc-skill-trace"))`
- `src/cli/index.ts:619`（uninstall）: `preToolUse.filter((h) => !JSON.stringify(h).includes("cc-skill-trace"))`

issue に記載の再現ケース（`description` に `cc-skill-trace` を含むだけの無関係な Bash フック）で、旧ロジックが `true` を返す＝誤検知することをテストで確認した。

## Changes

- `src/cli/hooks.ts` を新規追加。`isCcSkillTraceHook(entry)` ヘルパーが `hooks[].command` フィールドを直接検査し、cc-skill-trace が登録する `cc-skill-trace hook-capture` コマンドに一致する場合のみ `true` を返す。絶対パスや `npx` などでラップされた command にも対応（`includes` 判定）。malformed / 非オブジェクトのエントリに対しても安全。
  - CLI エントリポイント（読み込み時に `program.parse()` を実行する）を import せずにユニットテストできるよう、独立モジュールとして配置。
- `src/cli/index.ts`: install / uninstall 双方で `JSON.stringify().includes()` の代わりに `isCcSkillTraceHook` を使用。
- `src/cli/hooks.test.ts`: 正常系・ラップされた command・#187 の誤検知回帰・無関係フック・malformed 入力をカバーするテストを追加。
- `package.json`: `test` スクリプトに新テストファイルを追加。

## Test plan

- [x] `npm test` passes （60 tests, 全 pass。うち新規 5 tests）
- [x] `npm run typecheck` passes
- [x] Manually tested: 新テストで旧実装が誤検知していたケース（`description` のみに文字列が含まれる無関係フック）が新実装では `false` になることを確認

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（hook-capture のロジックは変更なし）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_017bjuk9kk3jBqGTK5ihmBF1)_