### PR TITLE
fix: SKILL.md のインストール確認に `where` フォールバックを追加し Windows ネイティブに対応 (#170)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/skill/skill-md.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: true
 ---
 
 ```bash
-which cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
+which cc-skill-trace 2>/dev/null || where cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
 cc-skill-trace show --scan --terse -n 15 2>/dev/null
 ```
 

--- a/src/skill/skill-md.test.ts
+++ b/src/skill/skill-md.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// Read the bundled SKILL.md next to this test file.
+const skillMd = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), "SKILL.md"),
+  "utf-8"
+);
+
+// Extract the first fenced ```bash block — this is the install check run by /skill-trace.
+const bashBlock = skillMd.match(/```bash\n([\s\S]*?)```/)?.[1] ?? "";
+
+describe("SKILL.md install check", () => {
+  it("has a bash code block", () => {
+    assert.ok(bashBlock.length > 0, "expected a ```bash block in SKILL.md");
+  });
+
+  // On Windows native, `which` does not exist (the equivalent is `where`). Without a
+  // `where` fallback the check always prints "NOT INSTALLED" even when the CLI is
+  // installed. (#170)
+  it("falls back to `where` for cross-platform (Windows) detection", () => {
+    assert.match(bashBlock, /which cc-skill-trace/, "expected a `which` lookup");
+    assert.match(
+      bashBlock,
+      /where cc-skill-trace/,
+      "expected a `where` fallback for Windows native shells (#170)"
+    );
+  });
+
+  it("checks `which` before `where` so mac/Linux behavior is unchanged", () => {
+    const whichIdx = bashBlock.indexOf("which cc-skill-trace");
+    const whereIdx = bashBlock.indexOf("where cc-skill-trace");
+    assert.ok(whichIdx >= 0 && whereIdx > whichIdx, "`where` must come after `which`");
+  });
+
+  it("still shows the NOT INSTALLED hint as the final fallback", () => {
+    const whereIdx = bashBlock.indexOf("where cc-skill-trace");
+    const notInstalledIdx = bashBlock.indexOf("NOT INSTALLED");
+    assert.ok(
+      notInstalledIdx > whereIdx,
+      "the NOT INSTALLED branch must remain the last fallback"
+    );
+  });
+});


### PR DESCRIPTION
Closes #170

## Summary

Windows ネイティブ（PowerShell / CMD）には `which` コマンドが存在しないため、`src/skill/SKILL.md` のインストール確認 `which cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED..."; exit 0; }` が常に失敗し、`cc-skill-trace` がインストール済みでも `/skill-trace` 実行時に必ず "NOT INSTALLED" と表示されていた。`which` が失敗した場合に Windows 相当の `where cc-skill-trace` を試すフォールバックを追加する。

## 妥当性検証

- `src/skill/SKILL.md:11` を確認し、`which cc-skill-trace` のみで `where` フォールバックが存在しないことを確認（issue の主張どおり）。Windows ネイティブでは `which` が未定義のため、CLI がインストール済みでも常に NOT INSTALLED 分岐に落ちる。
- `report` コマンドが `process.platform === "win32"` を扱っている前例があり、Windows 対応の方針はリポジトリと整合する。
- 短絡評価により `which` が先に評価されるため、`which` が存在する macOS / Linux では従来どおり最初の分岐で解決し、挙動は変わらない。`which` が失敗する場合のみ `where`（Linux では未定義 → exit 非 0、stderr は `2>/dev/null` で抑制）を経て、最終的に従来どおり NOT INSTALLED を表示する。

## Changes

- `src/skill/SKILL.md`: `which ... || where cc-skill-trace 2>/dev/null || { NOT INSTALLED }` にフォールバックを追加。
- `src/skill/skill-md.test.ts`（新規）: SKILL.md の bash ブロックに `where` フォールバックが存在すること、`which` → `where` → NOT INSTALLED の順序が保たれることを検証する回帰テスト。
- `package.json`: 新しいテストファイルを `test` スクリプトに追加。

## Test plan

- [x] `npm test` passes（59 tests pass / 0 fail）
- [x] `npm run typecheck` passes
- [x] Manually verified: SKILL.md の bash ブロックで `which` が先に評価され、macOS/Linux では従来分岐で解決、`where` は `which` 失敗時のみ実行され最終フォールバックは NOT INSTALLED のまま。

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本 PR は hook-capture を変更しない）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_018zWnTRELav6eihtsBWjnGs)_