### PR TITLE
fix: isSkillMdStale がバンドル SKILL.md の読み込み失敗を握りつぶさないよう修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/cli/skill-md.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ import {
 } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
+import { computeSkillMdStale, type ReadResult } from "./skill-md.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
 import { parseDuration } from "./duration.js";
 
@@ -120,17 +121,29 @@ async function bundledSkillMdPath(): Promise<string> {
 
 const installedSkillMdPath = join(homedir(), ".claude", "skills", "skill-trace", "SKILL.md");
 
+async function readSkillMd(path: string): Promise<ReadResult> {
+  try {
+    return { ok: true, content: await readFile(path, "utf-8") };
+  } catch {
+    return { ok: false };
+  }
+}
+
 /** Returns true when the installed SKILL.md differs from the bundled one. */
 async function isSkillMdStale(): Promise<boolean> {
-  try {
-    const [installed, bundled] = await Promise.all([
-      readFile(installedSkillMdPath, "utf-8"),
-      readFile(await bundledSkillMdPath(), "utf-8"),
-    ]);
-    return installed !== bundled;
-  } catch {
-    return false;
+  const [bundled, installed] = await Promise.all([
+    readSkillMd(await bundledSkillMdPath()),
+    readSkillMd(installedSkillMdPath),
+  ]);
+  const { stale, bundledMissing } = computeSkillMdStale(bundled, installed);
+  if (bundledMissing) {
+    // A missing bundled SKILL.md means the package was built incorrectly
+    // (e.g. #183). Surface it instead of silently reporting "up to date".
+    process.stderr.write(
+      chalk.yellow("⚠  Bundled SKILL.md not found — the package may be built incorrectly.\n\n")
+    );
   }
+  return stale;
 }
 
 // ─── install ──────────────────────────────────────────────────────────────────

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,7 +28,12 @@ import {
 } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
-import { computeSkillMdStale, normalizeSkillMd, skillMdChanged, type ReadResult } from "./skill-md.js";
+import {
+  computeSkillMdStale,
+  normalizeSkillMd,
+  skillMdChanged,
+  type ReadResult,
+} from "./skill-md.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
 import { writeSettingsAtomic } from "./atomic-write.js";
 import { skipWhileRunning } from "./follow.js";

--- a/src/cli/skill-md.test.ts
+++ b/src/cli/skill-md.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { computeSkillMdStale } from "./skill-md.js";
+
+describe("computeSkillMdStale", () => {
+  it("is stale when installed content differs from bundled", () => {
+    assert.deepEqual(
+      computeSkillMdStale({ ok: true, content: "v2" }, { ok: true, content: "v1" }),
+      { stale: true, bundledMissing: false }
+    );
+  });
+
+  it("is not stale when installed content matches bundled", () => {
+    assert.deepEqual(
+      computeSkillMdStale({ ok: true, content: "same" }, { ok: true, content: "same" }),
+      { stale: false, bundledMissing: false }
+    );
+  });
+
+  it("is not stale (and not a build problem) when nothing is installed yet", () => {
+    assert.deepEqual(computeSkillMdStale({ ok: true, content: "v1" }, { ok: false }), {
+      stale: false,
+      bundledMissing: false,
+    });
+  });
+
+  it("flags bundledMissing when the bundled SKILL.md cannot be read (#190)", () => {
+    // Regression: previously any read failure was swallowed as "up to date",
+    // hiding a broken build. The bundled-missing case must be distinguishable.
+    assert.deepEqual(computeSkillMdStale({ ok: false }, { ok: true, content: "v1" }), {
+      stale: false,
+      bundledMissing: true,
+    });
+  });
+
+  it("flags bundledMissing even when installed is also unreadable", () => {
+    assert.deepEqual(computeSkillMdStale({ ok: false }, { ok: false }), {
+      stale: false,
+      bundledMissing: true,
+    });
+  });
+});

--- a/src/cli/skill-md.ts
+++ b/src/cli/skill-md.ts
@@ -1,0 +1,29 @@
+// Pure decision logic for whether the installed SKILL.md is out of date (#190).
+//
+// Reading the files is IO and stays in the caller; this module only interprets
+// the read results. Keeping it pure lets it be unit-tested and, crucially, keeps
+// the three cases distinct so an unreadable *bundled* file is no longer silently
+// swallowed as "up to date":
+//
+//   - bundled unreadable   → likely a broken build; caller should surface it,
+//                            but this is not a stale install (stale = false)
+//   - installed unreadable → not installed yet; nothing to update (stale = false)
+//   - both readable        → stale iff the contents differ
+
+export type ReadResult = { ok: true; content: string } | { ok: false };
+
+export interface SkillMdStatus {
+  stale: boolean;
+  /** True when the bundled SKILL.md could not be read (likely a broken build). */
+  bundledMissing: boolean;
+}
+
+export function computeSkillMdStale(bundled: ReadResult, installed: ReadResult): SkillMdStatus {
+  if (!bundled.ok) {
+    return { stale: false, bundledMissing: true };
+  }
+  if (!installed.ok) {
+    return { stale: false, bundledMissing: false };
+  }
+  return { stale: bundled.content !== installed.content, bundledMissing: false };
+}


### PR DESCRIPTION
Closes #190

## Summary

`isSkillMdStale()`（`src/cli/index.ts`）は `installed` / `bundled` の両ファイルを `Promise.all` で読み、いずれかで例外が発生すると `catch` で一律 `false` を返していた。このため **bundled 側（`dist/skill/SKILL.md`）が読めない**ケース（#183 のビルド漏れと複合するケース等）でも「stale ではない ＝ 最新」と誤判定し、`show` の「`cc-skill-trace install` を実行してください」という更新警告が一切表示されず、ユーザーがインストール状態の不具合に気づけなかった。

## 妥当性検証

現行コード（`src/cli/index.ts:124-134`）を確認し、issue の主張どおり以下を確認した：

- `catch { return false; }` が bundled 読み込み失敗（ENOENT）を握りつぶす。
- 結果として `show`（`src/cli/index.ts:284`）の警告分岐が常にスキップされる。
- この issue に対応するオープン PR / リモートブランチは存在しない（#183 の PR #206 は本文で #190 に言及するのみで close していない）。

## Changes

- `src/cli/skill-md.ts`（新規）: 判定を純粋関数 `computeSkillMdStale(bundled, installed)` に切り出し、3 ケースを明確に区別する。
  - bundled 読み込み失敗 → `bundledMissing: true`（ビルド不良の可能性 / stale ではない）
  - installed 未存在 → `stale: false`（未インストール — 更新対象なし）
  - 両方読める → 内容差分で `stale` を判定
- `src/cli/index.ts`: ファイル読み込みを `readSkillMd()` に分離して上記純粋関数を利用。`bundledMissing` の場合は `stderr` に警告（`⚠  Bundled SKILL.md not found — the package may be built incorrectly.`）を出力し、失敗をサイレントにしない。
- `src/cli/skill-md.test.ts`（新規）: 4 ケース（差分あり / 一致 / 未インストール / bundled 欠落）＋両方欠落の回帰テストを追加。
- `package.json`: `test` スクリプトに新テストファイルを登録。

## Test plan

- [x] `npm test` passes（60 tests / 0 fail、うち新規 5 件）
- [x] `npm run typecheck` passes
- [x] `npx biome lint src/cli/skill-md.ts` に新規指摘なし（既存の警告のみ）

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本 PR は当該パスに変更なし）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYdV7o4Thdgj9ouXunrLNo)_