### PR TITLE
fix: hook-capture と scan の重複イベントを排除し二重登録を防ぐ (#182)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,7 @@ import {
   appendEvent,
   pruneEvents,
   backupEvents,
+  selectNewEvents,
   EVENTS_FILE,
 } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
@@ -94,15 +95,14 @@ async function scanAndMerge(opts: {
   sessionId?: string;
 }): Promise<{ events: Awaited<ReturnType<typeof readEvents>>; imported: number }> {
   const events = await extractAllInvocations({ ...opts, onProgress: scanProgress });
-  const existingIds = new Set((await readEvents()).map((e) => e.id));
-  let imported = 0;
-  for (const ev of events) {
-    if (!existingIds.has(ev.id)) {
-      await appendEvent(ev);
-      imported++;
-    }
+  // Dedup against everything already stored — including hook-captured events,
+  // which carry a random UUID rather than the scan's tool_use id, so a plain
+  // id match would re-import every one of them (#182).
+  const toImport = selectNewEvents(await readEvents(), events);
+  for (const ev of toImport) {
+    await appendEvent(ev);
   }
-  return { events, imported };
+  return { events, imported: toImport.length };
 }
 
 program

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
-import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount } from "./store.js";
+import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount, selectNewEvents, DEDUP_WINDOW_MS } from "./store.js";
 import type { SkillInvocationEvent } from "./types.js";
 
 function makeEvent(overrides: Partial<SkillInvocationEvent> = {}): SkillInvocationEvent {
@@ -236,6 +236,72 @@ describe("store", () => {
       assert.equal(result.kept, 0);
       const remaining = await readEvents(dir);
       assert.deepEqual(remaining, []);
+    });
+  });
+
+  describe("selectNewEvents (#182)", () => {
+    // A hook-captured event (random UUID) and the scan-captured event for the
+    // same invocation (tool_use id) must be recognised as one, so scan doesn't
+    // store a second copy of every hook event.
+    const hookEvent = makeEvent({
+      id: "uuid-random-1234",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      sessionId: "s1",
+      skillName: "commit",
+      source: "user",
+    });
+    const scanOfSameInvocation = makeEvent({
+      id: "toolu_abc123",
+      // scan reads the assistant message timestamp — close to but not equal to
+      // the hook's fire time.
+      timestamp: "2026-01-01T00:00:02.500Z",
+      sessionId: "s1",
+      skillName: "commit",
+      source: "claude",
+    });
+
+    it("drops a scanned event that matches a stored hook event by session/skill/args + time window", () => {
+      const fresh = selectNewEvents([hookEvent], [scanOfSameInvocation]);
+      assert.deepEqual(fresh, []);
+    });
+
+    it("keeps a scanned event whose timestamp is outside the dedup window", () => {
+      const later = makeEvent({
+        ...scanOfSameInvocation,
+        id: "toolu_later",
+        timestamp: new Date(Date.parse(hookEvent.timestamp) + DEDUP_WINDOW_MS + 1000).toISOString(),
+      });
+      const fresh = selectNewEvents([hookEvent], [later]);
+      assert.deepEqual(fresh.map((e) => e.id), ["toolu_later"]);
+    });
+
+    it("does not merge events with different skill args", () => {
+      const other = makeEvent({
+        ...scanOfSameInvocation,
+        id: "toolu_diff_args",
+        skillArgs: "--force",
+      });
+      const fresh = selectNewEvents([makeEvent({ ...hookEvent, skillArgs: "--dry-run" })], [other]);
+      assert.deepEqual(fresh.map((e) => e.id), ["toolu_diff_args"]);
+    });
+
+    it("does not merge events from different sessions", () => {
+      const other = makeEvent({ ...scanOfSameInvocation, id: "toolu_other_session", sessionId: "s2" });
+      const fresh = selectNewEvents([hookEvent], [other]);
+      assert.deepEqual(fresh.map((e) => e.id), ["toolu_other_session"]);
+    });
+
+    it("is idempotent across repeated scans (exact id already stored)", () => {
+      const fresh = selectNewEvents([scanOfSameInvocation], [scanOfSameInvocation]);
+      assert.deepEqual(fresh, []);
+    });
+
+    it("preserves two distinct invocations of the same skill in one scan batch", () => {
+      const first = makeEvent({ id: "toolu_1", timestamp: "2026-01-01T00:00:00.000Z", sessionId: "s1", skillName: "commit" });
+      const second = makeEvent({ id: "toolu_2", timestamp: "2026-01-01T00:00:01.000Z", sessionId: "s1", skillName: "commit" });
+      // Candidates are only compared against `existing`, never each other, so both survive.
+      const fresh = selectNewEvents([], [first, second]);
+      assert.deepEqual(fresh.map((e) => e.id).sort(), ["toolu_1", "toolu_2"]);
     });
   });
 });

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -122,6 +122,49 @@ export async function readEvents(
   return events;
 }
 
+// ─── Cross-source deduplication (#182) ───────────────────────────────────────
+// `hook-capture` assigns each event a random UUID, while `scan` uses the Skill
+// `tool_use` id (e.g. "toolu_abc123") from the session log. The same invocation
+// therefore gets two different ids, so id-based dedup never matches and `scan`
+// stores a second copy of every hook-captured event. We treat a scanned event
+// and a stored event as the *same* invocation when they share session, skill
+// name and args and their timestamps fall within this window — the PreToolUse
+// hook fires within about a second of the assistant message whose timestamp
+// `scan` reads, so the window only needs to absorb that small skew (and must
+// stay short enough not to merge two deliberate re-runs of the same skill).
+export const DEDUP_WINDOW_MS = 5000;
+
+function sameInvocation(a: SkillInvocationEvent, b: SkillInvocationEvent): boolean {
+  if (a.sessionId !== b.sessionId) return false;
+  if (a.skillName !== b.skillName) return false;
+  if ((a.skillArgs ?? "") !== (b.skillArgs ?? "")) return false;
+  const dt = Math.abs(Date.parse(a.timestamp) - Date.parse(b.timestamp));
+  return Number.isFinite(dt) && dt <= DEDUP_WINDOW_MS;
+}
+
+/**
+ * From freshly scanned `candidates`, return only the events not already present
+ * in `existing`. A candidate is dropped when its id already exists (repeated
+ * scans) or when it matches an existing event by session, skill, args and
+ * timestamp window — which is how a scan result lines up with the
+ * hook-captured record of the same invocation (#182). Candidates are only
+ * compared against `existing`, never against each other, so distinct scanned
+ * invocations (each with its own `tool_use` id) are always preserved.
+ */
+export function selectNewEvents(
+  existing: SkillInvocationEvent[],
+  candidates: SkillInvocationEvent[]
+): SkillInvocationEvent[] {
+  const existingIds = new Set(existing.map((e) => e.id));
+  const fresh: SkillInvocationEvent[] = [];
+  for (const ev of candidates) {
+    if (existingIds.has(ev.id)) continue;
+    if (existing.some((e) => sameInvocation(e, ev))) continue;
+    fresh.push(ev);
+  }
+  return fresh;
+}
+
 export function clearEvents(dir = STORE_DIR): Promise<void> {
   return enqueueWrite(dir, async () => {
     await ensureStoreDir(dir);


### PR DESCRIPTION
Closes #182

## Summary

`hook-capture` はイベント ID を `randomUUID()` で生成する一方、`scan` はセッションログの `tool_use` ブロックの `id`（例: `toolu_abc123`）を使用する。同一のスキル発動でも両者が別々の ID を割り当てるため、`scanAndMerge` の ID ベースの重複排除（`existingIds.has(ev.id)`）が機能せず、**hook で記録済みのイベントが `scan` 実行時にすべて二重登録されていた**。

### 妥当性検証

現行コードで問題が実在することを確認した:

- `src/cli/index.ts` の `hook-capture`: `id: randomUUID()`（`src/cli/index.ts:243`）
- `src/core/parser.ts` の `extractInvocationsFromFile`: `id: call.id`（`src/core/parser.ts:232`）
- `scanAndMerge` の重複排除: `const existingIds = new Set((await readEvents()).map((e) => e.id))` → `if (!existingIds.has(ev.id))`（旧 `src/cli/index.ts:97-100`）

`uuid-xxxx` と `toolu_abc123` は常に異なる値なので、`install` 後に `scan` / `show --scan` を実行するたびに hook 記録イベントと同じ発動が再登録され、`show` に同一タイムスタンプ・スキル名のイベントが 2 件表示される。issue の再現手順どおり成立する。

## Changes

- `src/core/store.ts`: 純粋関数 `selectNewEvents(existing, candidates)` を追加。候補（scan 結果）のうち、以下のいずれかに該当するものを除外して返す:
  - ID が既存イベントに存在する（従来どおりの再スキャン冪等性）
  - `(sessionId, skillName, skillArgs)` が一致し、かつタイムスタンプ差が `DEDUP_WINDOW_MS`（5 秒）以内の既存イベントがある → hook と scan が記録した「同一発動」とみなす
  - 候補同士は比較せず `existing` とのみ照合するため、同一スキルの**異なる**発動（それぞれ固有の `tool_use` id を持つ）は常に保持される
  - ウィンドウ判定は `source` を鍵に含めないため、hook（`user_invoked` ベースの正確な値）と scan（正規表現による推論）で `source` 判定が食い違うケースでも正しく重複排除できる
- `src/cli/index.ts`: `scanAndMerge` の手書き ID 重複排除を `selectNewEvents` の呼び出しに置き換え

`SkillInvocationEvent` のスキーマ・ストレージ形式・`hook-capture` の挙動（常に exit 0）は一切変更していない。

## Test plan

- [x] `npm test` passes（61 tests, all pass）
- [x] `npm run typecheck` passes
- [x] `src/core/store.test.ts` に `selectNewEvents` のテストを追加:
  - hook イベントと同一発動の scan イベントを重複排除する
  - ウィンドウ外のタイムスタンプは別発動として保持する
  - `skillArgs` / `sessionId` が異なる場合は重複排除しない
  - 再スキャン時（同一 ID）は冪等
  - 1 回の scan バッチ内の同一スキルの異なる発動は両方保持する

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（hook 側は未変更）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkNWzKKX682D7sM3EgtaGs)_