### PR TITLE
fix: バージョン取得をディレクトリ構造非依存にして CLI クラッシュを防ぐ (#173)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/core/utils.test.ts src/cli/format.test.ts src/cli/duration.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/core/utils.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/cli/version.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,9 +14,9 @@ import { program } from "commander";
 import chalk from "chalk";
 import { readFile, writeFile, rename, copyFile as fsCopyFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
-import { createRequire } from "node:module";
 import {
   readEvents,
   clearEvents,
@@ -29,9 +29,9 @@ import { extractAllInvocations } from "../core/parser.js";
 import { buildHtmlReport } from "./web-report.js";
 import { renderDashboard, renderCompact, renderTerse, renderStats, buildStats } from "./format.js";
 import { parseDuration } from "./duration.js";
+import { resolveVersion } from "./version.js";
 
-const _require = createRequire(import.meta.url);
-const VERSION = (_require("../../package.json") as { version: string }).version;
+const VERSION = resolveVersion(dirname(fileURLToPath(import.meta.url)));
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T[\d:.Z+-]*)?$/;
 

--- a/src/cli/version.test.ts
+++ b/src/cli/version.test.ts
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveVersion, FALLBACK_VERSION } from "./version.js";
+
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "cc-skill-trace-version-"));
+}
+
+test("resolves version from package.json in the start directory", async () => {
+  const dir = await makeTempDir();
+  try {
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "cc-skill-trace", version: "1.2.3" })
+    );
+    assert.equal(resolveVersion(dir), "1.2.3");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("walks up to find package.json when start dir has none (dist structure change)", async () => {
+  const root = await makeTempDir();
+  try {
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({ name: "cc-skill-trace", version: "4.5.6" })
+    );
+    // Simulate a deeper/relocated compiled layout, e.g. dist/cli/ or a bundle.
+    const deep = join(root, "dist", "cli", "chunks");
+    await mkdir(deep, { recursive: true });
+    assert.equal(resolveVersion(deep), "4.5.6");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("prefers the cc-skill-trace manifest over a nearer, differently-named one", async () => {
+  const root = await makeTempDir();
+  try {
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({ name: "cc-skill-trace", version: "9.9.9" })
+    );
+    // A nearer package.json belonging to something else (e.g. a bundler) must
+    // not shadow the real package version.
+    const nested = join(root, "node_modules", "other");
+    await mkdir(nested, { recursive: true });
+    await writeFile(
+      join(nested, "package.json"),
+      JSON.stringify({ name: "other-pkg", version: "0.0.1" })
+    );
+    assert.equal(resolveVersion(nested), "9.9.9");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("returns fallback instead of throwing when no package.json exists", async () => {
+  const dir = await makeTempDir();
+  try {
+    // Empty temp dir with no package.json anywhere up to the filesystem root.
+    assert.equal(resolveVersion(dir), FALLBACK_VERSION);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("returns fallback (does not throw) when package.json is malformed", async () => {
+  const dir = await makeTempDir();
+  try {
+    await writeFile(join(dir, "package.json"), "{ this is not valid json");
+    assert.equal(resolveVersion(dir), FALLBACK_VERSION);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+
+/** Returned when no readable `package.json` can be located (#173). */
+export const FALLBACK_VERSION = "0.0.0-unknown";
+
+const PACKAGE_NAME = "cc-skill-trace";
+
+/**
+ * Resolve this package's version by walking up from `startDir` to the nearest
+ * `package.json`.
+ *
+ * The previous implementation read `../../package.json` via a hardcoded
+ * relative path, which (a) breaks if the compiled layout under `dist/` changes
+ * or the code is bundled, and (b) throws at module load — crashing *every* CLI
+ * command, not just `--version`, when the manifest can't be resolved (#173).
+ *
+ * This resolver is structure-independent and never throws: it prefers the
+ * `package.json` whose `name` matches this package (so a parent/monorepo
+ * manifest isn't picked up), falls back to the first manifest with a valid
+ * version string, and finally to `FALLBACK_VERSION`.
+ */
+export function resolveVersion(startDir: string): string {
+  let dir = startDir;
+  const { root } = parse(dir);
+  let firstValid: string | undefined;
+
+  // Walk up to the filesystem root, inspecting a package.json at each level.
+  for (;;) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8")) as {
+        name?: unknown;
+        version?: unknown;
+      };
+      if (pkg && typeof pkg.version === "string") {
+        // Exact package match wins immediately.
+        if (pkg.name === PACKAGE_NAME) return pkg.version;
+        // Otherwise remember the closest valid version as a fallback.
+        if (firstValid === undefined) firstValid = pkg.version;
+      }
+    } catch {
+      // No package.json here, or it was unreadable/malformed — keep walking up.
+    }
+
+    if (dir === root) break;
+    dir = dirname(dir);
+  }
+
+  return firstValid ?? FALLBACK_VERSION;
+}


### PR DESCRIPTION
Closes #173

## Summary

`src/cli/index.ts` はモジュール読み込み時に `createRequire("../../package.json")` でバージョンを**即時**取得していました。この実装は `dist/cli/` という正確なディレクトリ構造に依存しており、パスが解決できない場合は最初のコマンド実行前に例外を投げます。その結果 `--version` だけでなく**すべての CLI コマンド**がモジュール読み込み時にクラッシュします。

### 妥当性検証（再現確認）

現行コードで実際に再現することを確認しました。`package.json` が解決できない状態にすると、`--version` に限らず `show` など全コマンドがロード時にクラッシュします:

```
$ mv package.json package.json.bak
$ node dist/cli/index.js show
Error: Cannot find module '../../package.json'   # ← 全コマンドが落ちる
```

修正後は同じ状況でもクラッシュせず、フォールバックで動作します:

```
$ node dist/cli/index.js --version
0.0.0-unknown
$ node dist/cli/index.js show        # 正常に動作（exit 0）
```

通常インストール時は従来どおり正しいバージョンを返します（`--version` → `1.0.0`）。

## Changes

- `src/cli/version.ts` を新規追加。`resolveVersion(startDir)` はモジュールのディレクトリから上位に向かって最寄りの `package.json` を探索し、`name === "cc-skill-trace"` の manifest を優先、`version` フィールドを検証したうえで、見つからない/壊れている場合は例外を投げずに `FALLBACK_VERSION` (`0.0.0-unknown`) を返します。ディレクトリ構造が変わっても解決でき、ロード時にクラッシュしません。
- `src/cli/index.ts`: `createRequire` によるハードコードされた相対パス読み込みを `resolveVersion(dirname(fileURLToPath(import.meta.url)))` に置き換え。未使用となった `createRequire` の import を削除。
- `src/cli/version.test.ts` を新規追加（開始ディレクトリでの解決 / 上位探索 / 名前一致の優先 / package.json 欠損時のフォールバック / 不正 JSON 時のフォールバック）。
- `package.json` の `test` スクリプトに新テストを追加。

外部ランタイム依存は追加していません（`node:fs` / `node:path` / `node:url` のみ）。

## Test plan

- [x] `npm test` passes（67 tests、うち新規 5 件）
- [x] `npm run typecheck` passes
- [x] Manually tested: `npm run build` 後、通常時の `--version` = `1.0.0`、`package.json` 非存在時の `--version` = `0.0.0-unknown` かつ `show` が正常動作（exit 0）することを確認

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（当該パスは未変更）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkRNc4XaDpRrFu7bTtZWfZ)_