### PR TITLE
fix: parser が user_invoked フラグを優先して source を判定する (#177)

### DIFF
--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -71,6 +71,60 @@ describe("extractInvocationsFromFile", () => {
     assert.equal(events[0].source, "user");
   });
 
+  it("prefers an explicit user_invoked flag over the trigger-message heuristic (#177)", async () => {
+    // Trigger text starts with "/commit" so the regex heuristic alone would
+    // mislabel this as user-invoked, but Claude Code recorded user_invoked=false.
+    const file = join(dir, "explicit-claude.jsonl");
+    await writeFile(file, jsonl([
+      userMsg("/commit コマンドについて教えて"),
+      {
+        type: "message",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        sessionId: "sess-1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "tu-1", name: "Skill", input: { skill: "commit" }, user_invoked: false },
+          ],
+        },
+      },
+    ]));
+    const events = await extractInvocationsFromFile(file);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].source, "claude", "explicit user_invoked=false must win over the regex");
+  });
+
+  it("honors an entry-level user_invoked=true even when trigger text lacks a slash (#177)", async () => {
+    const file = join(dir, "explicit-user.jsonl");
+    await writeFile(file, jsonl([
+      userMsg("please summarize this"),
+      {
+        type: "message",
+        timestamp: "2026-01-01T00:00:01.000Z",
+        sessionId: "sess-1",
+        user_invoked: true,
+        message: {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu-1", name: "Skill", input: { skill: "pdf" } }],
+        },
+      },
+    ]));
+    const events = await extractInvocationsFromFile(file);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].source, "user", "explicit user_invoked=true must win over the regex");
+  });
+
+  it("falls back to the trigger-message heuristic when user_invoked is absent (#177)", async () => {
+    const file = join(dir, "no-flag-heuristic.jsonl");
+    await writeFile(file, jsonl([
+      userMsg("/pdf rotate this"),
+      assistantSkill("pdf"),
+    ]));
+    const events = await extractInvocationsFromFile(file);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].source, "user");
+  });
+
   it("extracts multiple Skill calls from one assistant message", async () => {
     const file = join(dir, "multi-skill.jsonl");
     await writeFile(file, jsonl([

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -198,12 +198,24 @@ export async function extractInvocationsFromFile(
       const skillArgs = call.input.args ? String(call.input.args) : undefined;
 
       // Detect user-invoked vs Claude auto-invoked.
+      // Prefer the authoritative `user_invoked` flag if Claude Code recorded it
+      // on the tool_use block or the entry — this matches how the real-time
+      // hook-capture path determines `source`. Fall back to inferring from the
+      // preceding message text only when the flag is absent (#177).
+      const explicitUserInvoked =
+        typeof call.user_invoked === "boolean"
+          ? call.user_invoked
+          : typeof entry.user_invoked === "boolean"
+            ? entry.user_invoked
+            : undefined;
+
       const bareSkillName = skillName.includes(":") ? skillName.split(":").pop()! : skillName;
       const slashCmdRe = new RegExp(
         `^/(${escapeRegExp(skillName)}|${escapeRegExp(bareSkillName)})(\\s|$)`,
         "i"
       );
-      const isUserInvoked = slashCmdRe.test(triggerMessage?.trimStart() ?? "");
+      const isUserInvoked =
+        explicitUserInvoked ?? slashCmdRe.test(triggerMessage?.trimStart() ?? "");
 
       // Estimate injectedTokens from the tool_result that follows this call (#34).
       // The next user message should contain a tool_result block with matching tool_use_id.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,6 +7,12 @@ export interface ToolUse {
   id: string;
   name: string;
   input: Record<string, unknown>;
+  /**
+   * Present when Claude Code recorded whether the invocation came from a user
+   * slash command. When available this is authoritative and should be preferred
+   * over inferring `source` from the preceding message text (#177).
+   */
+  user_invoked?: boolean;
 }
 
 export interface ToolResult {
@@ -37,6 +43,11 @@ export interface SessionLogEntry {
   timestamp: string;
   sessionId?: string;
   uuid?: string;
+  /**
+   * Entry-level flag set by Claude Code when the invocation was triggered by a
+   * user slash command. Preferred over regex inference of `source` (#177).
+   */
+  user_invoked?: boolean;
   costUSD?: number;
   usage?: {
     input_tokens: number;


### PR DESCRIPTION
Closes #177

## Summary

`scan` / `parser.ts` の `source` 判定が `triggerMessage` の正規表現推論のみに依存していたため、リアルタイムの `hook-capture`（正確な `user_invoked` フラグを使用）と結果が食い違う問題を修正する。

**妥当性検証（現行コードで再現を確認）:**
- `hook-capture` (`src/cli/index.ts:248`) は Claude Code のフックペイロードに含まれる `user_invoked` を使って正確に判定していた。
- 一方 `parser.ts:206` は `^/(skillName)(\s|$)` の正規表現で `triggerMessage` を推論するのみ。そのため「`/commit` コマンドについて教えて」のような文は、Claude の自動発動であっても `source: "user"` と誤判定される（issue 記載のシナリオ 1 を確認）。
- 重複除去 (`scanAndMerge`, `index.ts:81-88`) は `id` ベースの append-only で、既存イベントの `source` を書き換えることはない → Acceptance criteria 2 は現行実装で既に満たされていることを確認した。

## Changes

- `src/core/types.ts`: `ToolUse` と `SessionLogEntry` に任意フィールド `user_invoked?: boolean` を追加（後方互換：省略時は従来どおり）。
- `src/core/parser.ts`: セッションログの `tool_use` ブロックまたはエントリに `user_invoked` が記録されていればそれを優先し、無い場合のみ従来の正規表現フォールバックを使うよう変更。
- `src/core/parser.test.ts`: 不整合ケースのテストを 3 件追加（明示フラグ `false` が正規表現に勝つ / エントリレベル `true` が勝つ / フラグ不在時のフォールバック）。

## Test plan

- [x] `npm test` passes（78 件全通過、うち新規 3 件）
- [x] `npm run typecheck` passes
- [x] Manually tested: `/commit ...` を含む triggerMessage + `user_invoked: false` の合成セッションログで `source: "claude"` になることを確認

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（変更なし）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（フィールド追加は任意・パーサ内部型のみ）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_017trFGFGVTHQa8oZZQnkGzx)_