### PR TITLE
feat: export --format csv に --no-bom フラグを追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:fix": "biome lint src --write",
     "format": "biome format src --write",
     "format:check": "biome format src",
-    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/core/utils.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/cli/follow.test.ts src/cli/skill-md.test.ts src/cli/atomic-write.test.ts src/cli/copy-skill.test.ts",
+    "test": "node --import tsx/esm --test src/core/store.test.ts src/core/parser.test.ts src/core/utils.test.ts src/cli/format.test.ts src/cli/duration.test.ts src/cli/follow.test.ts src/cli/skill-md.test.ts src/cli/atomic-write.test.ts src/cli/csv.test.ts src/cli/copy-skill.test.ts",
     "prepare": "npm run build",
     "prepublishOnly": "npm run typecheck && npm run lint && npm test"
   },

--- a/src/cli/csv.test.ts
+++ b/src/cli/csv.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { toCsv, CSV_HEADERS } from "./csv.js";
+import type { SkillInvocationEvent } from "../core/types.js";
+
+const BOM = "\uFEFF";
+
+function ev(overrides: Partial<SkillInvocationEvent> = {}): SkillInvocationEvent {
+  return {
+    id: "evt-1",
+    timestamp: "2026-01-03T00:00:00.000Z",
+    sessionId: "sess-A",
+    skillName: "commit",
+    source: "claude",
+    ...overrides,
+  };
+}
+
+describe("toCsv", () => {
+  it("prepends a UTF-8 BOM by default", () => {
+    const out = toCsv([ev()]);
+    assert.equal(out[0], BOM);
+    // The header row must start with the BOM immediately followed by the first column.
+    assert.ok(out.startsWith(`${BOM}"id",`));
+  });
+
+  it("omits the BOM when bom: false (#193 --no-bom)", () => {
+    const out = toCsv([ev()], { bom: false });
+    assert.equal(out.startsWith(BOM), false);
+    assert.ok(out.startsWith(`"id",`));
+    // First byte is the ASCII quote, so Unix tooling sees a clean "id" column.
+    assert.equal(out.charCodeAt(0), '"'.charCodeAt(0));
+  });
+
+  it("emits the full header row in order", () => {
+    const out = toCsv([], { bom: false });
+    const header = out.split("\n")[0];
+    assert.equal(header, CSV_HEADERS.map((h) => `"${h}"`).join(","));
+  });
+
+  it("renders one row per event with fields in header order", () => {
+    const out = toCsv(
+      [ev({ id: "a", skillName: "review", injectedTokens: 42 })],
+      { bom: false },
+    );
+    const rows = out.split("\n");
+    assert.equal(rows.length, 2);
+    assert.equal(rows[1], "a,2026-01-03T00:00:00.000Z,sess-A,review,,claude,,42,,");
+  });
+
+  it("quotes and escapes fields containing commas, quotes, or newlines", () => {
+    const out = toCsv(
+      [ev({ triggerMessage: 'hi, "there"\nbye' })],
+      { bom: false },
+    );
+    // The trigger message column is index 6; it must be wrapped in quotes with
+    // internal double-quotes doubled, and the embedded newline preserved verbatim.
+    assert.ok(out.includes('"hi, ""there""\nbye"'));
+  });
+
+  it("renders undefined optional fields as empty strings", () => {
+    const out = toCsv([ev()], { bom: false });
+    const row = out.split("\n")[1];
+    // skillArgs, triggerMessage, injectedTokens, cwd, gitBranch are all unset.
+    assert.equal(row, "evt-1,2026-01-03T00:00:00.000Z,sess-A,commit,,claude,,,,");
+  });
+});

--- a/src/cli/csv.ts
+++ b/src/cli/csv.ts
@@ -1,0 +1,45 @@
+import type { SkillInvocationEvent } from "../core/types.js";
+
+/** Columns emitted by `export --format csv`, in order. */
+export const CSV_HEADERS: (keyof SkillInvocationEvent)[] = [
+  "id",
+  "timestamp",
+  "sessionId",
+  "skillName",
+  "skillArgs",
+  "source",
+  "triggerMessage",
+  "injectedTokens",
+  "cwd",
+  "gitBranch",
+];
+
+export interface ToCsvOptions {
+  /**
+   * Prepend a UTF-8 BOM so Excel opens non-ASCII text without garbling (#193).
+   * Set to `false` (via `--no-bom`) for Unix tooling (csvkit, pandas, awk, …)
+   * that treats the BOM bytes as part of the first field name. Default: `true`.
+   */
+  bom?: boolean;
+}
+
+/** UTF-8 byte order mark (U+FEFF). */
+const BOM = "\uFEFF";
+
+/** Escape a single CSV field per RFC 4180 (quote if it contains , " or newline). */
+function escapeField(value: unknown): string {
+  const s = value == null ? "" : String(value);
+  return s.includes(",") || s.includes('"') || s.includes("\n")
+    ? `"${s.replace(/"/g, '""')}"`
+    : s;
+}
+
+/** Serialize events to a CSV string, optionally prefixed with a UTF-8 BOM. */
+export function toCsv(events: SkillInvocationEvent[], options: ToCsvOptions = {}): string {
+  const bom = options.bom ?? true;
+  const body =
+    CSV_HEADERS.map((h) => `"${h}"`).join(",") +
+    "\n" +
+    events.map((e) => CSV_HEADERS.map((h) => escapeField(e[h])).join(",")).join("\n");
+  return (bom ? BOM : "") + body;
+}

--- a/src/cli/csv.ts
+++ b/src/cli/csv.ts
@@ -29,9 +29,7 @@ const BOM = "\uFEFF";
 /** Escape a single CSV field per RFC 4180 (quote if it contains , " or newline). */
 function escapeField(value: unknown): string {
   const s = value == null ? "" : String(value);
-  return s.includes(",") || s.includes('"') || s.includes("\n")
-    ? `"${s.replace(/"/g, '""')}"`
-    : s;
+  return s.includes(",") || s.includes('"') || s.includes("\n") ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
 /** Serialize events to a CSV string, optionally prefixed with a UTF-8 BOM. */

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -32,6 +32,7 @@ import { writeSettingsAtomic } from "./atomic-write.js";
 import { normalizeSkillMd, skillMdChanged } from "./skill-md.js";
 import { skipWhileRunning } from "./follow.js";
 import { parseDuration } from "./duration.js";
+import { toCsv } from "./csv.js";
 
 const _require = createRequire(import.meta.url);
 const VERSION = (_require("../../package.json") as { version: string }).version;
@@ -488,6 +489,7 @@ program
   .command("export")
   .description("Export captured events as JSON or CSV")
   .option("--format <fmt>", "Output format: json | csv", "json")
+  .option("--no-bom", "Omit the UTF-8 BOM from CSV output (BOM is on by default for Excel)")
   .option("-o, --output <path>", "Output file path (default: stdout)")
   .option("--since <date>", "Filter from this ISO date", validateSince)
   .option("--before <date>", "Filter up to this ISO date", validateSince)
@@ -511,30 +513,8 @@ program
     let out: string;
 
     if (fmt === "csv") {
-      const headers: (keyof (typeof events)[0])[] = [
-        "id",
-        "timestamp",
-        "sessionId",
-        "skillName",
-        "skillArgs",
-        "source",
-        "triggerMessage",
-        "injectedTokens",
-        "cwd",
-        "gitBranch",
-      ];
-      const esc = (v: unknown) => {
-        const s = v == null ? "" : String(v);
-        return s.includes(",") || s.includes('"') || s.includes("\n")
-          ? `"${s.replace(/"/g, '""')}"`
-          : s;
-      };
-      // UTF-8 BOM ensures Excel opens the file without garbling non-ASCII characters
-      out =
-        "\uFEFF" +
-        headers.map((h) => `"${h}"`).join(",") +
-        "\n" +
-        events.map((e) => headers.map((h) => esc(e[h])).join(",")).join("\n");
+      // `--no-bom` sets opts.bom to false; BOM stays on by default for Excel.
+      out = toCsv(events, { bom: opts.bom as boolean });
     } else if (fmt === "json") {
       out = JSON.stringify(events, null, 2);
     } else {


### PR DESCRIPTION
Closes #193

## Summary

`export --format csv` は Excel 互換のため常に先頭へ UTF-8 BOM (`EF BB BF`) を付与していた。しかし BOM は csvkit・pandas（`utf-8-sig` 未指定時）・`awk`/`wc`/`grep` などの Unix ツールで先頭フィールド名に混入し、`ï»¿id` のように壊れる原因になる。

このPRは CSV 出力から BOM を省略する `--no-bom` フラグを追加する。**デフォルトは従来どおり BOM あり**（後方互換）で、Unix ツール向けに `--no-bom` を渡すと BOM なしのクリーンな CSV を出力する。issue #193 のタイトルの提案に沿い、デフォルト挙動は変更していない。

## 妥当性検証

- `src/cli/index.ts` の export コマンドは CSV 出力時に `"" + ...` で BOM を無条件付与しており、これを無効化する手段が存在しないことをコードで確認した。
- `export --format json` には BOM 付与が無く、この変更の影響を受けないことを確認した（今回も未変更）。

## Changes

- CSV シリアライズ処理を純粋関数 `toCsv(events, { bom })` として `src/cli/csv.ts` に抽出（ヘッダー定義・RFC 4180 エスケープを含む）。既存のインライン実装と挙動は同一。
- `export` コマンドに `--no-bom` オプションを追加（commander の `--no-*` により `opts.bom` は既定 `true`、指定時 `false`）。
- `src/cli/csv.test.ts` を追加し、BOM あり/なし・ヘッダー列順・フィールドエスケープ（`,` `"` 改行）・未設定オプションフィールドの空文字化をユニットテストで検証。`package.json` の `test` スクリプトに追加。

## Test plan

- [x] `npm test` passes（81 tests, 追加分含め全て pass）
- [x] `npm run typecheck` passes
- [x] Manually tested: ビルド後に実際の CLI で非 ASCII スキル名を含むイベントをエクスポートし、先頭バイトを確認。
  - デフォルト: `ef bb bf 22 69 64`（BOM + `"id`）
  - `--no-bom`: `22 69 64 22`（`"id"`、BOM なし）
  - `--format json --no-bom`: JSON 出力は影響なし

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本変更は `export` コマンドのみに影響）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ未変更）

🤖 このPRは定期ルーティンにより自動生成されました


---
_Generated by [Claude Code](https://claude.ai/code/session_01Chgm6U6dADon5EJkhDkQrz)_