### PR TITLE
fix: プロセス間ファイルロックで events.jsonl の並行書き込み競合を防ぐ (#161)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ src/
 - ターミナル出力は box-drawing 文字 + ANSI カラーで視認性を最大化（`format.ts:renderDashboard`）
 - HTML レポートは依存ゼロのスタンドアロンファイル（Chart.js は CDN）
 - イベントストアは JSONL（SQLite は v2 で検討）
+- **並行安全性**（`store.ts`, #161）: `appendEvent` は `fs.appendFile`（O_APPEND）を使い、小さな 1 行の追記はアトミック。複数の `hook-capture` プロセスが同時に追記してもデータは失われない。一方 `clearEvents` / `pruneEvents` / `backupEvents` はファイル全体を read-modify-write するため、プロセス間ロック（`events.jsonl.lock` の排他生成 = `open(path, "wx")`）で直列化する。ロックファイルが `LOCK_STALE_MS`(30s) より古い場合はクラッシュ跡と見なして自動回収するのでデッドロックしない。`appendEvent` はホットパスのためロックを短時間だけ待ち、取れなければ素の追記にフォールバックして Claude Code を絶対にブロックしない。プロセス内の直列化は `writeQueues` プロミスチェーンが担い、プロセス間はこのファイルロックが担う。
 - `CC_DEBUG=1` 環境変数で `hook-capture` のデバッグログを stderr に出力
 - `CC_SCAN_CONCURRENCY` 環境変数でスキャン並列数を変更（デフォルト: 8）
 - `CC_PROJECTS_DIR` 環境変数でスキャン対象ディレクトリを変更（先頭の `~/` はホームディレクトリに展開される）

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, before, after, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { appendFile } from "node:fs/promises";
-import { mkdtemp, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { appendFile, mkdtemp, open, rm, readFile, utimes, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount } from "./store.js";
 import type { SkillInvocationEvent } from "./types.js";
 
@@ -199,6 +200,92 @@ describe("store", () => {
 
       const current = await readFile(join(bDir, "events.jsonl.bak"), "utf-8");
       assert.match(current, /"id":"gen-2"/);
+    });
+  });
+
+  describe("cross-process concurrency (#161)", () => {
+    const lockFile = (d: string) => join(d, "events.jsonl.lock");
+
+    it("appendEvent still records the event when another process holds the lock (never blocks)", async () => {
+      const cDir = dir + "-lock-held";
+      await clearEvents(cDir);
+      // Simulate a live external holder by creating a fresh lock file.
+      const held = await open(lockFile(cDir), "wx");
+      await held.writeFile("999999 held\n", "utf-8");
+      await held.close();
+
+      // appendEvent must not hang — it falls back to a bare append after a short wait.
+      const started = Date.now();
+      await appendEvent(makeEvent({ id: "under-lock" }), cDir);
+      assert.ok(Date.now() - started < 3000, "append should not block indefinitely");
+
+      const events = await readEvents(cDir);
+      assert.deepEqual(events.map((e) => e.id), ["under-lock"]);
+      await rm(lockFile(cDir), { force: true });
+    });
+
+    it("reclaims a stale lock left behind by a crashed process", async () => {
+      const cDir = dir + "-stale-lock";
+      await clearEvents(cDir);
+      await appendEvent(makeEvent({ id: "before" }), cDir);
+
+      // Leave a lock file whose mtime is well past the staleness window (30s).
+      await writeFile(lockFile(cDir), "12345 crashed\n", "utf-8");
+      const longAgo = new Date(Date.parse("2020-01-01T00:00:00.000Z"));
+      await utimes(lockFile(cDir), longAgo, longAgo);
+
+      // A whole-file rewrite must reclaim the stale lock rather than time out.
+      await pruneEvents("1970-01-01T00:00:00.000Z", cDir);
+      assert.equal(existsSync(lockFile(cDir)), false, "stale lock should be removed");
+      const events = await readEvents(cDir);
+      assert.deepEqual(events.map((e) => e.id), ["before"]);
+    });
+
+    it("does not lose appends when many processes write concurrently", async () => {
+      const cDir = dir + "-multiproc";
+      await clearEvents(cDir);
+
+      const storeUrl = new URL("./store.ts", import.meta.url).href;
+      const workerPath = join(cDir, "..", "cc-skill-trace-append-worker.mjs");
+      await writeFile(
+        workerPath,
+        `const [storeUrl, dir, eventJson] = process.argv.slice(2);\n` +
+          `const { appendEvent } = await import(storeUrl);\n` +
+          `await appendEvent(JSON.parse(eventJson), dir);\n`,
+        "utf-8"
+      );
+
+      const N = 12;
+      const spawnAppend = (i: number): Promise<number> =>
+        new Promise((resolve, reject) => {
+          const ev = makeEvent({
+            id: `proc-${i}`,
+            timestamp: `2026-02-01T00:00:00.${String(i).padStart(3, "0")}Z`,
+          });
+          const child = spawn(
+            process.execPath,
+            ["--import", "tsx/esm", workerPath, storeUrl, cDir, JSON.stringify(ev)],
+            { stdio: "ignore" }
+          );
+          child.on("error", reject);
+          child.on("exit", (code) => resolve(code ?? 0));
+        });
+
+      const codes = await Promise.all(Array.from({ length: N }, (_, i) => spawnAppend(i)));
+      assert.ok(codes.every((c) => c === 0), "all worker processes should exit cleanly");
+
+      // Read the raw file: every line must be valid JSON (no torn/interleaved writes)
+      // and all N events must be present (no lost appends).
+      const raw = await readFile(join(cDir, "events.jsonl"), "utf-8");
+      const lines = raw.split("\n").filter((l) => l.trim());
+      for (const line of lines) {
+        assert.doesNotThrow(() => JSON.parse(line), `line should be valid JSON: ${line}`);
+      }
+      const ids = (await readEvents(cDir)).map((e) => e.id).sort();
+      assert.deepEqual(
+        ids,
+        Array.from({ length: N }, (_, i) => `proc-${i}`).sort()
+      );
     });
   });
 

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, open, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { SkillInvocationEvent } from "./types.js";
@@ -8,6 +8,101 @@ export const EVENTS_FILE = join(STORE_DIR, "events.jsonl");
 
 export async function ensureStoreDir(dir = STORE_DIR): Promise<void> {
   await mkdir(dir, { recursive: true });
+}
+
+// ─── Cross-process file lock ─────────────────────────────────────────────────
+// The in-process write queue (below) only serializes writes within a *single*
+// process. When Claude Code fires skills in parallel it can spawn several
+// `hook-capture` processes at once, and the user may run `clear`/prune from the
+// CLI while a session is live — all separate OS processes contending for the
+// same events.jsonl. Appends are safe on their own (fs.appendFile opens with
+// O_APPEND, so each small line is written atomically and never interleaves),
+// but the whole-file read-modify-write operations (prune/clear/backup) can
+// silently clobber a concurrent append: they read the file, then overwrite it
+// with the old contents, dropping anything appended in between.
+//
+// We coordinate those operations across processes with an advisory lock built
+// on exclusive file creation (`open(path, "wx")` fails with EEXIST if the lock
+// already exists). A lock file older than LOCK_STALE_MS is presumed to belong
+// to a crashed holder and is reclaimed, so a dead process can never deadlock
+// the store (#161).
+
+const LOCK_STALE_MS = 30_000; // a lock file older than this is treated as abandoned
+const LOCK_POLL_MS = 15; // interval between acquisition attempts while a lock is held
+/** Whole-file rewrites (prune/clear/backup) wait this long before giving up. */
+const LOCK_WAIT_MS = 2_000;
+/**
+ * Appends run on the hook hot path and must never block Claude Code, so they
+ * wait only briefly for the lock and then fall back to a bare (still atomic)
+ * append. Worst case this is no worse than the pre-#161 behaviour.
+ */
+const APPEND_LOCK_WAIT_MS = 250;
+
+const delay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function lockPath(dir: string): string {
+  return join(dir, "events.jsonl.lock");
+}
+
+/**
+ * Try to acquire the cross-process lock for `dir`, waiting up to `maxWaitMs`.
+ * Returns a release function on success, or `null` if the lock could not be
+ * acquired in time (the caller decides whether to fall back or fail).
+ */
+async function acquireFileLock(
+  dir: string,
+  maxWaitMs: number
+): Promise<(() => Promise<void>) | null> {
+  await ensureStoreDir(dir);
+  const path = lockPath(dir);
+  const start = Date.now();
+  for (;;) {
+    try {
+      const handle = await open(path, "wx");
+      await handle.writeFile(`${process.pid} ${new Date().toISOString()}\n`, "utf-8");
+      await handle.close();
+      let released = false;
+      return async () => {
+        if (released) return;
+        released = true;
+        await rm(path, { force: true }).catch(() => {});
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      // Lock is held — reclaim it if it looks abandoned, otherwise wait.
+      try {
+        const st = await stat(path);
+        if (Date.now() - st.mtimeMs > LOCK_STALE_MS) {
+          await rm(path, { force: true }).catch(() => {});
+          continue; // stale lock cleared — retry immediately
+        }
+      } catch {
+        continue; // lock vanished between open and stat — retry immediately
+      }
+      if (Date.now() - start >= maxWaitMs) return null;
+      await delay(LOCK_POLL_MS);
+    }
+  }
+}
+
+/**
+ * Run `fn` while holding the cross-process lock for `dir`. Throws if the lock
+ * cannot be acquired within `LOCK_WAIT_MS` rather than risk clobbering a
+ * concurrent write. Used for the whole-file rewrite operations.
+ */
+async function withFileLock<T>(dir: string, fn: () => Promise<T>): Promise<T> {
+  const release = await acquireFileLock(dir, LOCK_WAIT_MS);
+  if (!release) {
+    throw new Error(
+      `cc-skill-trace: could not acquire store lock for ${dir} within ${LOCK_WAIT_MS}ms ` +
+        `(a stale ${lockPath(dir)} can be removed manually)`
+    );
+  }
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
 }
 
 // ─── Write serialization queue ───────────────────────────────────────────────
@@ -74,7 +169,16 @@ export interface ReadEventsOptions {
 export function appendEvent(event: SkillInvocationEvent, dir = STORE_DIR): Promise<void> {
   return enqueueWrite(dir, async () => {
     await ensureStoreDir(dir);
-    await appendFile(join(dir, "events.jsonl"), JSON.stringify(event) + "\n", "utf-8");
+    const line = JSON.stringify(event) + "\n";
+    // Coordinate with a concurrent prune/clear when we can, but never block the
+    // hook: if the lock is contended past APPEND_LOCK_WAIT_MS, fall back to a
+    // bare O_APPEND write (atomic on its own, so appends still never interleave).
+    const release = await acquireFileLock(dir, APPEND_LOCK_WAIT_MS).catch(() => null);
+    try {
+      await appendFile(join(dir, "events.jsonl"), line, "utf-8");
+    } finally {
+      if (release) await release();
+    }
   });
 }
 
@@ -123,10 +227,12 @@ export async function readEvents(
 }
 
 export function clearEvents(dir = STORE_DIR): Promise<void> {
-  return enqueueWrite(dir, async () => {
-    await ensureStoreDir(dir);
-    await writeFile(join(dir, "events.jsonl"), "", "utf-8");
-  });
+  return enqueueWrite(dir, () =>
+    withFileLock(dir, async () => {
+      await ensureStoreDir(dir);
+      await writeFile(join(dir, "events.jsonl"), "", "utf-8");
+    })
+  );
 }
 
 export interface BackupResult {
@@ -143,34 +249,36 @@ export interface BackupResult {
  * overwritten. Returns `{ backupPath: null }` when there is nothing to back up.
  */
 export function backupEvents(dir = STORE_DIR): Promise<BackupResult> {
-  return enqueueWrite(dir, async () => {
-    const eventsPath = join(dir, "events.jsonl");
-    const bakPath = join(dir, "events.jsonl.bak");
-    const bakBakPath = join(dir, "events.jsonl.bak.bak");
+  return enqueueWrite(dir, () =>
+    withFileLock(dir, async () => {
+      const eventsPath = join(dir, "events.jsonl");
+      const bakPath = join(dir, "events.jsonl.bak");
+      const bakBakPath = join(dir, "events.jsonl.bak.bak");
 
-    let content: string;
-    try {
-      content = await readFile(eventsPath, "utf-8");
-    } catch {
-      // No store file yet — nothing to back up.
-      return { backupPath: null, rotatedTo: null };
-    }
+      let content: string;
+      try {
+        content = await readFile(eventsPath, "utf-8");
+      } catch {
+        // No store file yet — nothing to back up.
+        return { backupPath: null, rotatedTo: null };
+      }
 
-    await ensureStoreDir(dir);
+      await ensureStoreDir(dir);
 
-    // Preserve an existing backup instead of overwriting it.
-    let rotatedTo: string | null = null;
-    try {
-      const prev = await readFile(bakPath, "utf-8");
-      await writeFile(bakBakPath, prev, "utf-8");
-      rotatedTo = bakBakPath;
-    } catch {
-      // No existing backup to rotate.
-    }
+      // Preserve an existing backup instead of overwriting it.
+      let rotatedTo: string | null = null;
+      try {
+        const prev = await readFile(bakPath, "utf-8");
+        await writeFile(bakBakPath, prev, "utf-8");
+        rotatedTo = bakBakPath;
+      } catch {
+        // No existing backup to rotate.
+      }
 
-    await writeFile(bakPath, content, "utf-8");
-    return { backupPath: bakPath, rotatedTo };
-  });
+      await writeFile(bakPath, content, "utf-8");
+      return { backupPath: bakPath, rotatedTo };
+    })
+  );
 }
 
 /** Remove events whose timestamp is older than `beforeIso` (ISO string).
@@ -179,13 +287,15 @@ export function pruneEvents(
   beforeIso: string,
   dir = STORE_DIR
 ): Promise<{ removed: number; kept: number }> {
-  return enqueueWrite(dir, async () => {
-    await ensureStoreDir(dir);
-    const events = await readEvents(dir);
-    const kept = events.filter((e) => e.timestamp >= beforeIso);
-    const removed = events.length - kept.length;
-    const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length ? "\n" : "");
-    await writeFile(join(dir, "events.jsonl"), content, "utf-8");
-    return { removed, kept: kept.length };
-  });
+  return enqueueWrite(dir, () =>
+    withFileLock(dir, async () => {
+      await ensureStoreDir(dir);
+      const events = await readEvents(dir);
+      const kept = events.filter((e) => e.timestamp >= beforeIso);
+      const removed = events.length - kept.length;
+      const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length ? "\n" : "");
+      await writeFile(join(dir, "events.jsonl"), content, "utf-8");
+      return { removed, kept: kept.length };
+    })
+  );
 }


### PR DESCRIPTION
Closes #161

## Summary

複数の `hook-capture` プロセス（Claude Code のスキル並列発動）や CLI 操作が同時に `events.jsonl` へ書き込む際の競合を、プロセス間ファイルロックで防ぎます。

### 妥当性検証（issue の確認事項に対応）

現行コードを読んで問題の実在を確認しました。

1. **`appendEvent` は `fs.appendFile`（O_APPEND）を使用** → 小さな 1 行の追記はアトミックで、複数プロセスの並行追記でもデータは失われない（issue の指摘どおり安全）。
2. **`clearEvents` / `pruneEvents` / `backupEvents` は read-modify-write / ファイル全体上書き** → ここが本当のバグ。あるプロセスがファイルを読み → 別の `hook-capture` プロセスが追記 → 元プロセスが古い内容で上書き、で追記が**サイレントに消える**。
3. **プロセス内 `writeQueues` は単一プロセス内でしか直列化できない** → 別々の OS プロセスである複数の `hook-capture` 間の排他は担保されていなかった。

→ issue は妥当。修正対象は全体書き換え系の操作。

## Changes

- `store.ts` に `events.jsonl.lock` の排他生成（`open(path, "wx")`）を用いたプロセス間アドバイザリロックを追加。
- 全体書き換え操作（`clearEvents` / `pruneEvents` / `backupEvents`）をこのロックで直列化。ロックが取れない場合はデータ破壊を避けるためエラーを投げる。
- ロックファイルが `LOCK_STALE_MS`(30s) より古い場合はクラッシュしたプロセスの残骸と見なして自動回収 → デッドロックしない。
- `appendEvent`（フックのホットパス）はロックを短時間（250ms）だけ待ち、取れなければ素の O_APPEND 追記にフォールバック。**Claude Code を絶対にブロックしない**（最悪ケースでも #161 修正前と同等の挙動）。プロセス内の直列化は従来どおり `writeQueues` が担当。
- `CLAUDE.md` の Key design decisions に並行安全性の設計方針を追記。

## Test plan

- [x] `npm test` passes（78 tests, 0 fail）
- [x] `npm run typecheck` passes
- [x] Manually tested: `src/core/store.test.ts` に「cross-process concurrency (#161)」ブロックを追加
  - 外部プロセスがロック保持中でも `appendEvent` がブロックせずイベントを記録する（フォールバック）
  - クラッシュが残した stale ロックを全体書き換え操作が自動回収する
  - **実際に子プロセス 12 個を spawn して同一 store へ並行追記**し、全 12 件が欠落・破損なく記録されることを検証（ストレステスト）

## Checklist

- [x] No new external runtime dependencies added（`node:fs/promises` の `open`/`rm`/`stat` のみ使用）
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（append はロック待ちを 250ms に制限しフォールバック）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01Erijz4kvEHox3tqGD9Y6WE)_