### PR TITLE
fix: doctor コマンドで events.jsonl の破損検出と修復を追加する

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,6 +23,8 @@ import {
   appendEvent,
   pruneEvents,
   backupEvents,
+  checkStoreIntegrity,
+  fixStore,
   EVENTS_FILE,
 } from "../core/store.js";
 import { extractAllInvocations } from "../core/parser.js";
@@ -456,6 +458,58 @@ program
     } else {
       await clearEvents();
       console.log(chalk.green("✓  Cleared."));
+    }
+  });
+
+// ─── doctor ─────────────────────────────────────────────────────────────────────
+program
+  .command("doctor")
+  .description("Diagnose and repair the event store (events.jsonl)")
+  .option("--check-store", "Report integrity statistics for the event store")
+  .option("--fix-store", "Remove malformed/truncated lines (a .bak backup is created first)")
+  .action(async (opts) => {
+    const integrity = await checkStoreIntegrity();
+    const bad = integrity.malformedLines + integrity.truncatedLines;
+
+    console.log(chalk.bold("Event store: ") + integrity.storePath);
+    console.log(`  Total lines:     ${integrity.totalLines}`);
+    console.log(chalk.green(`  Valid events:    ${integrity.validEvents}`));
+    console.log(
+      (integrity.malformedLines ? chalk.yellow : chalk.gray)(
+        `  Malformed lines: ${integrity.malformedLines}`
+      )
+    );
+    console.log(
+      (integrity.truncatedLines ? chalk.yellow : chalk.gray)(
+        `  Truncated lines: ${integrity.truncatedLines}`
+      )
+    );
+
+    if (integrity.tmpLeftover) {
+      console.log(chalk.yellow(`\n⚠  Found incomplete write: ${integrity.tmpLeftover}`));
+      console.log(chalk.gray("   This may indicate a previous crash during prune/clear."));
+    }
+
+    if (opts.fixStore) {
+      if (bad === 0 && !integrity.tmpLeftover) {
+        console.log(chalk.green("\n✓  Store is clean — nothing to fix."));
+        return;
+      }
+      const res = await fixStore();
+      if (res.backupPath) console.log(chalk.gray(`\n  Backup written → ${res.backupPath}`));
+      console.log(
+        chalk.green(`✓  Removed ${res.removed} bad line(s), kept ${res.kept} valid event(s).`)
+      );
+      if (res.removedTmp)
+        console.log(chalk.green(`✓  Removed stray temp file → ${res.removedTmp}`));
+      return;
+    }
+
+    // Check-only mode (default, or explicit --check-store).
+    if (bad > 0 || integrity.tmpLeftover) {
+      console.log(chalk.yellow("\n⚠  Run `cc-skill-trace doctor --fix-store` to repair."));
+    } else {
+      console.log(chalk.green("\n✓  Store is clean."));
     }
   });
 

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -5,7 +5,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFile } from "node:fs/promises";
-import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount } from "./store.js";
+import { appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount, checkStoreIntegrity, fixStore } from "./store.js";
 import type { SkillInvocationEvent } from "./types.js";
 
 function makeEvent(overrides: Partial<SkillInvocationEvent> = {}): SkillInvocationEvent {
@@ -236,6 +236,104 @@ describe("store", () => {
       assert.equal(result.kept, 0);
       const remaining = await readEvents(dir);
       assert.deepEqual(remaining, []);
+    });
+  });
+
+  describe("checkStoreIntegrity (#175)", () => {
+    it("reports zero bad lines for a clean store", async () => {
+      const d = dir + "-integrity-clean";
+      await appendEvent(makeEvent({ id: "v1" }), d);
+      await appendEvent(makeEvent({ id: "v2" }), d);
+
+      const r = await checkStoreIntegrity(d);
+      assert.equal(r.storePath, join(d, "events.jsonl"));
+      assert.equal(r.totalLines, 2);
+      assert.equal(r.validEvents, 2);
+      assert.equal(r.malformedLines, 0);
+      assert.equal(r.truncatedLines, 0);
+      assert.equal(r.tmpLeftover, null);
+    });
+
+    it("classifies malformed vs truncated lines", async () => {
+      const d = dir + "-integrity-bad";
+      await appendEvent(makeEvent({ id: "v1" }), d);
+      // Structurally complete (ends with }) but invalid JSON → malformed.
+      await appendFile(join(d, "events.jsonl"), '{"id":"broken","ts":}\n', "utf-8");
+      // Cut off mid-write (no closing brace) → truncated.
+      await appendFile(join(d, "events.jsonl"), '{"id":"trunc","skillName":"revi\n', "utf-8");
+
+      const r = await checkStoreIntegrity(d);
+      assert.equal(r.totalLines, 3);
+      assert.equal(r.validEvents, 1);
+      assert.equal(r.malformedLines, 1);
+      assert.equal(r.truncatedLines, 1);
+    });
+
+    it("returns an empty report for a store that does not exist", async () => {
+      const r = await checkStoreIntegrity(dir + "-integrity-missing");
+      assert.equal(r.totalLines, 0);
+      assert.equal(r.validEvents, 0);
+      assert.equal(r.tmpLeftover, null);
+    });
+
+    it("detects a stray events.jsonl.tmp leftover", async () => {
+      const d = dir + "-integrity-tmp";
+      await appendEvent(makeEvent({ id: "v1" }), d);
+      const tmpPath = join(d, "events.jsonl.tmp");
+      await appendFile(tmpPath, "partial", "utf-8");
+
+      const r = await checkStoreIntegrity(d);
+      assert.equal(r.tmpLeftover, tmpPath);
+    });
+  });
+
+  describe("fixStore (#175)", () => {
+    it("removes bad lines, keeps valid events, and backs up the original", async () => {
+      const d = dir + "-fix-basic";
+      await appendEvent(makeEvent({ id: "keep-1" }), d);
+      await appendFile(join(d, "events.jsonl"), "NOT_VALID_JSON\n", "utf-8");
+      await appendEvent(makeEvent({ id: "keep-2" }), d);
+
+      const before = await readFile(join(d, "events.jsonl"), "utf-8");
+      const res = await fixStore(d);
+
+      assert.equal(res.removed, 1);
+      assert.equal(res.kept, 2);
+      assert.equal(res.backupPath, join(d, "events.jsonl.bak"));
+      assert.equal(res.removedTmp, null);
+
+      // The backup preserves the pre-repair content verbatim.
+      const backup = await readFile(join(d, "events.jsonl.bak"), "utf-8");
+      assert.equal(backup, before);
+
+      // The repaired store parses cleanly and retains both valid events.
+      const events = await readEvents(d);
+      assert.deepEqual(events.map((e) => e.id).sort(), ["keep-1", "keep-2"]);
+
+      const after = await checkStoreIntegrity(d);
+      assert.equal(after.malformedLines + after.truncatedLines, 0);
+    });
+
+    it("removes a stray temp file even when the store is already clean", async () => {
+      const d = dir + "-fix-tmp";
+      await appendEvent(makeEvent({ id: "v1" }), d);
+      const tmpPath = join(d, "events.jsonl.tmp");
+      await appendFile(tmpPath, "partial", "utf-8");
+
+      const res = await fixStore(d);
+      assert.equal(res.removed, 0);
+      assert.equal(res.kept, 1);
+      assert.equal(res.removedTmp, tmpPath);
+
+      const after = await checkStoreIntegrity(d);
+      assert.equal(after.tmpLeftover, null);
+    });
+
+    it("is a no-op backup-wise when there is no store file", async () => {
+      const res = await fixStore(dir + "-fix-missing");
+      assert.equal(res.backupPath, null);
+      assert.equal(res.removed, 0);
+      assert.equal(res.kept, 0);
     });
   });
 });

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, appendFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { SkillInvocationEvent } from "./types.js";
@@ -187,5 +187,160 @@ export function pruneEvents(
     const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length ? "\n" : "");
     await writeFile(join(dir, "events.jsonl"), content, "utf-8");
     return { removed, kept: kept.length };
+  });
+}
+
+// ─── Integrity: check & repair (#175) ─────────────────────────────────────────
+// A crash mid-write can leave a truncated event at the tail of events.jsonl, and
+// an interrupted prune/clear can leave a stray `events.jsonl.tmp`. `readEvents`
+// silently skips unparseable lines (correct, but invisible to the user), so
+// `doctor` surfaces and repairs these conditions.
+
+export interface StoreIntegrity {
+  /** Absolute path of the inspected store file. */
+  storePath: string;
+  /** Non-empty lines in the file. */
+  totalLines: number;
+  /** Lines that parse as JSON. */
+  validEvents: number;
+  /** Lines that fail to parse but look structurally complete (end with `}`). */
+  malformedLines: number;
+  /** Lines that fail to parse and appear cut off mid-write (no closing `}`). */
+  truncatedLines: number;
+  /** Path to a stray `events.jsonl.tmp` left by an interrupted write, else null. */
+  tmpLeftover: string | null;
+}
+
+/** Path of a leftover temp file from an interrupted prune/clear, or null. */
+async function findTmpLeftover(dir: string): Promise<string | null> {
+  const tmpPath = join(dir, "events.jsonl.tmp");
+  try {
+    await access(tmpPath);
+    return tmpPath;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Inspect the event store without modifying it. Reports how many lines are
+ * valid, malformed, or truncated, and whether a stray temp file is present.
+ */
+export async function checkStoreIntegrity(dir = STORE_DIR): Promise<StoreIntegrity> {
+  const storePath = join(dir, "events.jsonl");
+
+  let raw = "";
+  try {
+    raw = await readFile(storePath, "utf-8");
+  } catch {
+    // No store file yet — treated as an empty store.
+  }
+
+  let totalLines = 0;
+  let validEvents = 0;
+  let malformedLines = 0;
+  let truncatedLines = 0;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    totalLines++;
+    try {
+      JSON.parse(trimmed);
+      validEvents++;
+    } catch {
+      // A line cut off mid-write won't have its closing brace; a structurally
+      // complete but otherwise invalid line will.
+      if (trimmed.endsWith("}")) {
+        malformedLines++;
+      } else {
+        truncatedLines++;
+      }
+    }
+  }
+
+  return {
+    storePath,
+    totalLines,
+    validEvents,
+    malformedLines,
+    truncatedLines,
+    tmpLeftover: await findTmpLeftover(dir),
+  };
+}
+
+/** Copy `content` to `events.jsonl.bak`, rotating any existing backup to `.bak.bak`. */
+async function writeBackup(dir: string, content: string): Promise<string> {
+  const bakPath = join(dir, "events.jsonl.bak");
+  const bakBakPath = join(dir, "events.jsonl.bak.bak");
+  try {
+    const prev = await readFile(bakPath, "utf-8");
+    await writeFile(bakBakPath, prev, "utf-8");
+  } catch {
+    // No existing backup to rotate.
+  }
+  await writeFile(bakPath, content, "utf-8");
+  return bakPath;
+}
+
+export interface FixStoreResult {
+  /** Path of the backup written before repair, or null if there was no store file. */
+  backupPath: string | null;
+  /** Number of unparseable lines removed. */
+  removed: number;
+  /** Number of valid events retained. */
+  kept: number;
+  /** Path of a stray temp file that was removed, or null. */
+  removedTmp: string | null;
+}
+
+/**
+ * Rewrite the event store keeping only parseable lines. The original file is
+ * backed up to `events.jsonl.bak` first, and any leftover `events.jsonl.tmp`
+ * is removed. Serialized through the write queue so it never races a concurrent
+ * append/prune/clear.
+ */
+export function fixStore(dir = STORE_DIR): Promise<FixStoreResult> {
+  return enqueueWrite(dir, async () => {
+    await ensureStoreDir(dir);
+    const storePath = join(dir, "events.jsonl");
+
+    let raw: string | null = null;
+    try {
+      raw = await readFile(storePath, "utf-8");
+    } catch {
+      // No store file — nothing to rewrite, but still clean up any temp leftover.
+    }
+
+    let backupPath: string | null = null;
+    let removed = 0;
+    let kept = 0;
+    if (raw !== null) {
+      backupPath = await writeBackup(dir, raw);
+      const validLines: string[] = [];
+      for (const line of raw.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          JSON.parse(trimmed);
+          validLines.push(trimmed);
+        } catch {
+          removed++;
+        }
+      }
+      kept = validLines.length;
+      await writeFile(storePath, kept ? validLines.join("\n") + "\n" : "", "utf-8");
+    }
+
+    let removedTmp: string | null = null;
+    const tmpPath = join(dir, "events.jsonl.tmp");
+    try {
+      await access(tmpPath);
+      await rm(tmpPath, { force: true });
+      removedTmp = tmpPath;
+    } catch {
+      // No leftover temp file.
+    }
+
+    return { backupPath, removed, kept, removedTmp };
   });
 }


### PR DESCRIPTION
Closes #175

## Summary

`events.jsonl` は書き込み途中でプロセスがクラッシュすると末尾に切り詰められたイベントが残ることがある。`readEvents` は `JSON.parse` に失敗した行を静かにスキップするため（これ自体は正しい動作）、ユーザーには不完全なレコードが何件あるか分からなかった。また、prune/clear が中断すると `events.jsonl.tmp` の残骸が残る可能性もある。

本 PR はストアの整合性を診断・修復する `doctor` コマンドを追加する。

### 妥当性検証

- `src/core/store.ts:113-115` の `readEvents` が `JSON.parse` 失敗行を `catch` して黙ってスキップしていることを確認 → 破損行の可視性がないという issue の主張は実在する。
- `doctor` コマンドは未実装（`grep -rn doctor src/` が空）で、issue が要求する検出・修復機能はどこにも存在しないことを確認。

## Changes

- **`src/core/store.ts`**
  - `checkStoreIntegrity(dir)` を追加（読み取り専用）。総行数・有効イベント数・malformed 行数・truncated 行数・`.tmp` 残骸の有無を集計する。閉じ括弧 `}` の有無で「壊れているが構造は完結」（malformed）と「書き込み途中で切れた」（truncated）を分類する。
  - `fixStore(dir)` を追加。`.bak` バックアップ（既存バックアップは `.bak.bak` にローテーション）を作成してから不正な行を除去してクリーンなファイルを書き直し、`events.jsonl.tmp` の残骸を削除する。既存の書き込みキュー（`enqueueWrite`）経由で直列化し、並行する append/prune/clear と競合しない。
- **`src/cli/index.ts`**
  - `doctor` コマンドを追加（`--check-store` / `--fix-store`）。フラグなしでも整合性統計を表示する。`.tmp` 残骸を検出すると警告を表示する。
- **`src/core/store.test.ts`**
  - `checkStoreIntegrity` / `fixStore` のユニットテストを追加（クリーン／malformed・truncated 分類／ストア不在／`.tmp` 検出／バックアップと修復／`.tmp` 削除）。

## Test plan

- [x] `npm test` passes（82 tests, 0 fail）
- [x] `npm run typecheck` passes
- [x] Manually tested: 破損行 2 件（malformed 1 + truncated 1）と `.tmp` 残骸を含むストアに対し `doctor` → 統計と警告を表示、`doctor --fix-store` → `.bak` を作成して不正行 2 件を除去・有効 2 件を保持・`.tmp` を削除、再度 `doctor` → `Store is clean` を確認。

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（本 PR は hook-capture パスを変更しない）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（スキーマ変更なし）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_014XQ8TZRrVecDg6QErBY8dN)_