### PR TITLE
feat: add --session filter to list-skills command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -557,17 +557,19 @@ program
   .description("List all unique skills seen, with invocation counts")
   .option("--since <date>", "Filter from this ISO date", validateSince)
   .option("--before <date>", "Filter up to this ISO date", validateSince)
+  .option("--session <id>", "Filter by session ID")
   .option("--scan", "Scan session logs first")
   .option("--json", "Output as JSON")
   .action(async (opts) => {
     validateDateRange(opts.since, opts.before);
     if (opts.scan) {
-      const { imported } = await scanAndMerge({ since: opts.since });
+      const { imported } = await scanAndMerge({ since: opts.since, sessionId: opts.session });
       process.stderr.write(chalk.gray(`  Imported ${imported} new invocations.\n\n`));
     }
     const events = await readEvents({
       since: opts.since as string | undefined,
       before: opts.before as string | undefined,
+      sessionId: opts.session as string | undefined,
     });
 
     const stats = buildStats(events);

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -47,6 +47,17 @@ describe("store", () => {
       assert.deepEqual(range.map(e => e.id), ["mid"]);
     });
 
+    it("filters by sessionId at read time (#194)", async () => {
+      const sessionDir = dir + "-session";
+      await appendEvent(makeEvent({ id: "a", sessionId: "session-1" }), sessionDir);
+      await appendEvent(makeEvent({ id: "b", sessionId: "session-2" }), sessionDir);
+      await appendEvent(makeEvent({ id: "c", sessionId: "session-1" }), sessionDir);
+      const scoped = await readEvents({ dir: sessionDir, sessionId: "session-1" });
+      assert.deepEqual(scoped.map(e => e.id), ["a", "c"]);
+      const other = await readEvents({ dir: sessionDir, sessionId: "session-2" });
+      assert.deepEqual(other.map(e => e.id), ["b"]);
+    });
+
     it("respects limit option returning most recent events (#18)", async () => {
       const limitDir = dir + "-limit";
       for (let i = 1; i <= 5; i++) {


### PR DESCRIPTION
## Summary

Closes #194

`list-skills`（`ls`）は event を読むコマンドの中で唯一 `--session` フィルタを持っていませんでした。`show` / `stats` / `scan` / `export` / `report` はすべて `--session` をサポートしており、`list-skills` だけが未対応でした。特定のデバッグセッションで使われたスキルだけを確認できるよう、この非対称を解消します。

### 妥当性検証

- `src/cli/index.ts` の `list-skills` コマンド（実装前）には `--session` オプションが無く、`readEvents({ since, before })` に `sessionId` を渡していないことを確認。
- 他コマンドは同一の `readEvents({ ..., sessionId })` パターンで `--session` を実装済み。
- `src/core/store.ts` の `readEvents` は既に `options.sessionId` によるフィルタリングをサポート済み（他コマンドが利用中）だが、この挙動の専用ユニットテストは存在しなかった。

## Changes

- `list-skills` に `--session <id>` オプションを追加し、`readEvents` へ `sessionId` を渡すよう配線。
- `--scan` 併用時の `scanAndMerge` にも `sessionId` を渡し、他コマンドと挙動を統一。
- `src/core/store.test.ts` に `readEvents` の `sessionId` フィルタを検証するユニットテストを追加（#194）。

既存パターンに沿った最小変更で、新規依存やスキーマ変更はありません。

## Test plan

- [x] `npm test` passes（76 tests, 全 pass）
- [x] `npm run typecheck` passes
- [x] Manually tested: ビルド後に `list-skills --help` で `--session` が表示されることを確認。S1 / S2 の2セッション分のイベントを投入し、`list-skills --session S1 --json` が S1 のスキル（alpha）のみを返し、フィルタ無しでは両方（alpha, beta）が出ることを確認。

## Checklist

- [x] No new external runtime dependencies added
- [x] `hook-capture` path still exits 0 and never blocks Claude Code（未変更）
- [x] `SkillInvocationEvent` schema remains backwards-compatible（未変更）

🤖 このPRは定期ルーティンにより自動生成されました

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGNzJ6y89jRR4p7U4LZL18)_