### PR TITLE
chore: revert package.json version to 2.0.0 to unblock the v3.0.0 release workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-skill-trace",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Skill invocation debugger and visualizer for Claude Code — see which skills fired, when, and why",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
release.yml's \`workflow_dispatch\` bumps package.json's version itself via \`npm version <input> --no-git-tag-version\`. #222 hand-bumped package.json to 3.0.0 directly, so running the release workflow with \`version=3.0.0\` now fails at that step with "Version not changed". This reverts to 2.0.0 so the automated release (version bump PR, SSH-signed tag, GitHub Release, npm publish) can run as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)