### PR TITLE
fix: add missing checkout step to npm-token-check.yml

### DIFF
--- a/.github/workflows/npm-token-check.yml
+++ b/.github/workflows/npm-token-check.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # `gh issue create`/`gh issue list` resolve the target repo from the
+      # local git remote, so this checkout is required even though the job
+      # doesn't otherwise need any repo files.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20


### PR DESCRIPTION
Follow-up to the CI-hardening commit on \`main\` (44a403f). I manually triggered the new \`npm-token-check.yml\` via \`workflow_dispatch\` to validate it end-to-end and it failed at the issue-creation step: \`fatal: not a git repository\` — the job never had an \`actions/checkout\` step, and \`gh issue create\`/\`gh issue list\` need one to resolve the target repo. Added it.

Side effect of that same test run: it confirmed \`NPM_TOKEN\` currently gets a real \`401 Unauthorized\` from \`npm whoami\` in CI. This is a separate credential from the interactive \`npm login\` used to manually publish v3.0.0, so it's still broken for automated releases — worth rotating to a proper npmjs.com **Automation** token before the next \`workflow_dispatch\` release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)