### PR TITLE
chore(deps): bump commander from 12.1.0 to 15.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "commander": "^12.1.0"
+        "commander": "^15.0.0"
       },
       "bin": {
         "cc-skill-trace": "dist/cli/index.js"
@@ -22,7 +22,11 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/revo1290"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -653,12 +657,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "chalk": "^5.3.0",
-    "commander": "^12.1.0"
+    "commander": "^15.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",


### PR DESCRIPTION
Supersedes the stale dependabot PR #12. Verified locally: typecheck/build/lint/test (282/282) all pass, plus a manual CLI smoke test of `--version`/`--help`/subcommand help output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)