### PR TITLE
feat: support argument passthrough in /skill-trace (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Uninstalling removes only cc-skill-trace's own hook entries — any other tool's
 
 ### Use inside Claude Code (as a plugin)
 
-Type `/skill-trace` in the Claude Code chat to open the dashboard and have Claude explain why each skill was auto-triggered.
+Type `/skill-trace` in the Claude Code chat to open the dashboard and have Claude explain why each skill was auto-triggered. Arguments after `/skill-trace` are passed through to `cc-skill-trace show`, e.g. `/skill-trace --since 7d` or `/skill-trace --skill commit`; with no arguments it shows the most recent 15 events.
 
 ---
 
@@ -292,6 +292,14 @@ cc-skill-trace completion zsh >> ~/.zshrc   # shell completion: bash | zsh | fis
 ### 3. Claude Code skill (`/skill-trace`)
 
 Installing `~/.claude/skills/skill-trace/SKILL.md` lets you call `/skill-trace` from the Claude Code chat. Claude runs the dashboard and interprets the results — explaining why an auto-trigger rate is high, which skills fire unexpectedly, and how to narrow skill descriptions.
+
+Any arguments you type after `/skill-trace` are forwarded to `cc-skill-trace show --scan --terse` as-is (invalid flags are rejected by the CLI itself, not the skill). With no arguments it falls back to the previous default (`-n 15`):
+
+```
+/skill-trace                    # default: most recent 15 events
+/skill-trace --since 7d         # events from the last 7 days
+/skill-trace --skill commit     # only the "commit" skill
+```
 
 ---
 

--- a/src/skill/SKILL.md
+++ b/src/skill/SKILL.md
@@ -10,7 +10,12 @@ user-invocable: true
 
 ```bash
 which cc-skill-trace 2>/dev/null || where cc-skill-trace 2>/dev/null || { echo "NOT INSTALLED: npm install -g cc-skill-trace && cc-skill-trace install"; exit 0; }
-cc-skill-trace show --scan --terse -n 15 2>/dev/null
+ARGS="{{args}}"
+if [ -n "$ARGS" ]; then
+  cc-skill-trace show --scan --terse $ARGS 2>/dev/null
+else
+  cc-skill-trace show --scan --terse -n 15 2>/dev/null
+fi
 ```
 
 Show output verbatim. 2-sentence summary: auto-trigger rate; any skill auto-fired without clear user intent (suggest narrowing its `description:`). Offer: `report`, `--skill <name>`, `--since YYYY-MM-DD`.

--- a/src/skill/skill-md.test.ts
+++ b/src/skill/skill-md.test.ts
@@ -47,3 +47,39 @@ describe("SKILL.md install check", () => {
     );
   });
 });
+
+// #82: /skill-trace should pass user-provided arguments through to the CLI
+// instead of always running the fixed `-n 15` command.
+describe("SKILL.md argument passthrough (#82)", () => {
+  it("references the {{args}} placeholder", () => {
+    assert.match(
+      bashBlock,
+      /\{\{args\}\}/,
+      "expected the bash block to read Claude Code's {{args}} placeholder"
+    );
+  });
+
+  it("falls back to the default `-n 15` command when no args are given", () => {
+    assert.match(
+      bashBlock,
+      /cc-skill-trace show --scan --terse -n 15/,
+      "expected the empty-args branch to keep the previous default behavior"
+    );
+  });
+
+  it("passes non-empty args through to `cc-skill-trace show --scan --terse`", () => {
+    assert.match(
+      bashBlock,
+      /cc-skill-trace show --scan --terse \$ARGS/,
+      "expected user-supplied args to be forwarded to the show command"
+    );
+  });
+
+  it("keeps the not-installed check as an exit-0 no-op regardless of args (never blocks Claude Code)", () => {
+    assert.match(
+      bashBlock,
+      /NOT INSTALLED[^\n]*exit 0/,
+      "expected the not-installed branch to still exit 0"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `/skill-trace` previously always ran a fixed `cc-skill-trace show --scan --terse -n 15`, ignoring anything typed after the slash command.
- The bash block now reads Claude Code's `{{args}}` placeholder: empty args fall back to the existing `-n 15` default, non-empty args are forwarded to `cc-skill-trace show --scan --terse`, letting the CLI's own flag validation handle correctness.
- The install-check (`which`/`where` fallback → `NOT INSTALLED` hint) and the exit-0-on-not-installed safety pattern are unchanged — the hook still never blocks/errors Claude Code regardless of what the user typed.
- Updated README's `/skill-trace` sections with the new passthrough behavior and usage examples.

Closes #82

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build` (confirmed `dist/skill/SKILL.md` picked up the source change)
- [x] `npm test` — 286/286 passing (282 existing + 4 new assertions in `src/skill/skill-md.test.ts` covering `{{args}}` usage, the `-n 15` fallback, argument forwarding, and the exit-0 safety pattern)
- [x] Manually reviewed `dist/skill/SKILL.md` after build to confirm it's byte-identical to the edited `src/skill/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)