### PR TITLE
fix: eliminate all noNonNullAssertion lint warnings (#63)

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -417,7 +417,7 @@ async function runDoctor(opts: { checkStore?: boolean; fixStore?: boolean }): Pr
 
   if (!storeOnly) {
     // Node version
-    const major = parseInt(process.versions.node.split(".")[0]!, 10);
+    const major = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
     if (major >= 18) ok(`Node.js ${process.version} (>= 18)`);
     else bad(`Node.js ${process.version} — requires >= 18`);
 

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -169,7 +169,10 @@ async function runScanOnce(opts: {
   }
 
   let filtered = events;
-  if (opts.before) filtered = filtered.filter((e) => e.timestamp <= opts.before!);
+  if (opts.before) {
+    const before = opts.before;
+    filtered = filtered.filter((e) => e.timestamp <= before);
+  }
   if (opts.skill) filtered = filtered.filter((e) => e.skillName === opts.skill);
 
   if (opts.dryRun) {

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -246,7 +246,9 @@ export function registerShowCommand(program: Command): void {
 
       console.log(chalk.gray("  Enter/space: next · q: quit\n"));
       let i = 0;
-      printEvent(events[i]!, i);
+      const first = events[i];
+      if (!first) return;
+      printEvent(first, i);
       i++;
       if (i >= events.length) return;
 
@@ -259,7 +261,12 @@ export function registerShowCommand(program: Command): void {
             resolve();
             return;
           }
-          printEvent(events[i]!, i);
+          const ev = events[i];
+          if (!ev) {
+            resolve();
+            return;
+          }
+          printEvent(ev, i);
           i++;
           if (i >= events.length) resolve();
         });

--- a/src/cli/duration.ts
+++ b/src/cli/duration.ts
@@ -17,6 +17,7 @@ export function parseDuration(value: string): Date {
     );
     process.exit(1);
   }
+  // biome-ignore lint/style/noNonNullAssertion: group 1 (`\d+`) is mandatory in the pattern, so it's always captured once `match` itself is non-null.
   const n = parseInt(match[1]!, 10);
   const unit = match[2]?.toLowerCase();
   const cutoff = new Date();

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -165,11 +165,17 @@ export interface SkillStat {
 export function buildStats(events: SkillInvocationEvent[]): SkillStat[] {
   const map: Record<string, SkillStat> = {};
   for (const ev of events) {
-    if (!map[ev.skillName])
-      map[ev.skillName] = { name: ev.skillName, total: 0, auto: 0, byUser: 0, autoRate: 0 };
-    map[ev.skillName]!.total++;
-    if (ev.source === "claude") map[ev.skillName]!.auto++;
-    else map[ev.skillName]!.byUser++;
+    const stat = map[ev.skillName] ?? {
+      name: ev.skillName,
+      total: 0,
+      auto: 0,
+      byUser: 0,
+      autoRate: 0,
+    };
+    map[ev.skillName] = stat;
+    stat.total++;
+    if (ev.source === "claude") stat.auto++;
+    else stat.byUser++;
   }
   const stats = Object.values(map);
   for (const s of stats) s.autoRate = s.total === 0 ? 0 : Math.round((s.auto / s.total) * 100);
@@ -215,9 +221,10 @@ export function renderStats(events: SkillInvocationEvent[], opts: RenderStatsOpt
   const dayMap: Record<string, { total: number; auto: number }> = {};
   for (const ev of events) {
     const day = ev.timestamp.slice(0, 10);
-    if (!dayMap[day]) dayMap[day] = { total: 0, auto: 0 };
-    dayMap[day]!.total++;
-    if (ev.source === "claude") dayMap[day]!.auto++;
+    const stat = dayMap[day] ?? { total: 0, auto: 0 };
+    dayMap[day] = stat;
+    stat.total++;
+    if (ev.source === "claude") stat.auto++;
   }
   const days = Object.keys(dayMap).sort().slice(-dayWindow);
   const maxDay = Math.max(...days.map((d) => dayMap[d]?.total), 1);
@@ -227,6 +234,7 @@ export function renderStats(events: SkillInvocationEvent[], opts: RenderStatsOpt
   lines.push(section("  📅 Daily activity") + chalk.gray(`  (last ${dayWindow} days)`));
   lines.push("");
   for (const day of days) {
+    // biome-ignore lint/style/noNonNullAssertion: `days` is Object.keys(dayMap) (sorted/sliced), so every `day` here is a key that exists in dayMap.
     const d = dayMap[day]!;
     const autoB = "█".repeat(Math.round((d.auto / maxDay) * dayBarW));
     const userFill = Math.min(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // Node.js version gate — Intl.Segmenter requires Node 16+, fetch/structuredClone require 18+ (#39)
-const _nodeMajor = parseInt(process.versions.node.split(".")[0]!, 10);
+const _nodeMajor = parseInt(process.versions.node.split(".")[0] ?? "0", 10);
 if (_nodeMajor < 18) {
   process.stderr.write(
     `\ncc-skill-trace requires Node.js ≥ 18. You are running ${process.version}.\n` +

--- a/src/cli/web-report.ts
+++ b/src/cli/web-report.ts
@@ -39,12 +39,11 @@ export function buildHtmlReport(
   // ── Aggregation ──────────────────────────────────────────────────────────
   const skillCounts: Record<string, { total: number; byUser: number; byClaude: number }> = {};
   for (const ev of sourceEvents) {
-    if (!skillCounts[ev.skillName]) {
-      skillCounts[ev.skillName] = { total: 0, byUser: 0, byClaude: 0 };
-    }
-    skillCounts[ev.skillName]!.total++;
-    if (ev.source === "user") skillCounts[ev.skillName]!.byUser++;
-    else skillCounts[ev.skillName]!.byClaude++;
+    const counts = skillCounts[ev.skillName] ?? { total: 0, byUser: 0, byClaude: 0 };
+    skillCounts[ev.skillName] = counts;
+    counts.total++;
+    if (ev.source === "user") counts.byUser++;
+    else counts.byClaude++;
   }
 
   const topSkills = Object.entries(skillCounts)

--- a/src/core/analyze.ts
+++ b/src/core/analyze.ts
@@ -206,6 +206,7 @@ export function computeStreaks(events: SkillInvocationEvent[], today = new Date(
   const dayMs = 24 * 60 * 60 * 1000;
   const toUtc = (s: string) => Date.parse(`${s}T00:00:00Z`);
   for (let i = 1; i < sorted.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: i is in [1, sorted.length), so both sorted[i] and sorted[i - 1] are within bounds.
     if (toUtc(sorted[i]!) - toUtc(sorted[i - 1]!) === dayMs) run++;
     else run = 1;
     if (run > longest) longest = run;
@@ -281,6 +282,7 @@ export function estimateCost(events: SkillInvocationEvent[], model = "sonnet"): 
     : model.toLowerCase().includes("haiku")
       ? "haiku"
       : "sonnet";
+  // biome-ignore lint/style/noNonNullAssertion: key is narrowed to one of "opus"/"haiku"/"sonnet" above, and MODEL_INPUT_PRICES_PER_MTOK defines an entry for each.
   const price = MODEL_INPUT_PRICES_PER_MTOK[key]!;
   const perSkill = new Map<string, number>();
   let total = 0;

--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -92,6 +92,7 @@ export function parseDuration(value: string, now = new Date()): Date {
   if (!match) {
     throw new Error(`Invalid duration: "${value}". Expected e.g. 30min, 12h, 30d, 4w, 2mo, 1y`);
   }
+  // biome-ignore lint/style/noNonNullAssertion: group 1 (`\d+`) is mandatory in DURATION_RE, so it's always captured once `match` itself is non-null.
   const n = parseInt(match[1]!, 10);
   const unit = match[2]?.toLowerCase();
   const cutoff = new Date(now.getTime());
@@ -150,6 +151,7 @@ export function resolveDateInput(input: string, now = new Date()): string {
       month: "mo",
       year: "y",
     };
+    // biome-ignore lint/style/noNonNullAssertion: group 2 is a mandatory alternation covering exactly unitMap's keys, so it's always captured and always found.
     return parseDuration(`${ago[1]}${unitMap[ago[2]!]}`, now).toISOString();
   }
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -68,6 +68,7 @@ export async function mapWithLimit<T, R>(
   async function worker() {
     while (next < items.length) {
       const i = next++;
+      // biome-ignore lint/style/noNonNullAssertion: i is the pre-increment value of next, checked < items.length above, so items[i] is in bounds.
       results[i] = await fn(items[i]!);
     }
   }
@@ -235,6 +236,7 @@ export async function extractInvocationsFromFile(
 
   // Scan through entries looking for assistant messages that contain a Skill tool_use
   for (let i = 0; i < entries.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: i is bounded by entries.length above.
     const entry = entries[i]!;
     if (!entry.message) continue;
     const msg = entry.message;
@@ -249,6 +251,7 @@ export async function extractInvocationsFromFile(
     // Find the most recent user message before this entry
     let triggerMessage: string | undefined;
     for (let j = i - 1; j >= 0; j--) {
+      // biome-ignore lint/style/noNonNullAssertion: j starts at i - 1 (i < entries.length from the outer loop) and only decreases while j >= 0, so it stays in bounds.
       const prev = entries[j]!;
       if (!prev.message || prev.message.role !== "user") continue;
       const content = prev.message.content;
@@ -280,7 +283,9 @@ export async function extractInvocationsFromFile(
             ? entry.user_invoked
             : undefined;
 
-      const bareSkillName = skillName.includes(":") ? skillName.split(":").pop()! : skillName;
+      const bareSkillName = skillName.includes(":")
+        ? (skillName.split(":").pop() ?? skillName)
+        : skillName;
       const slashCmdRe = new RegExp(
         `^/(${escapeRegExp(skillName)}|${escapeRegExp(bareSkillName)})(\\s|$)`,
         "i"
@@ -292,6 +297,7 @@ export async function extractInvocationsFromFile(
       // The next user message should contain a tool_result block with matching tool_use_id.
       let injectedTokens: number | undefined;
       for (let j = i + 1; j < Math.min(i + 4, entries.length); j++) {
+        // biome-ignore lint/style/noNonNullAssertion: j < Math.min(i + 4, entries.length) guarantees j is in bounds.
         const next = entries[j]!;
         if (!next.message) continue;
         if (next.message.role !== "user") break;
@@ -361,7 +367,8 @@ export async function extractAllInvocations(
     fileInfos = await listSessionFiles();
   }
   if (opts.modifiedAfterMs != null) {
-    fileInfos = fileInfos.filter((f) => f.mtimeMs > opts.modifiedAfterMs!);
+    const modifiedAfterMs = opts.modifiedAfterMs;
+    fileInfos = fileInfos.filter((f) => f.mtimeMs > modifiedAfterMs);
   }
   let files = fileInfos.map((f) => f.path);
   if (opts.files) {

--- a/src/core/providers/codex.ts
+++ b/src/core/providers/codex.ts
@@ -208,6 +208,7 @@ async function extractInvocationsFromFile(
   const events: SkillInvocationEvent[] = [];
 
   for (let i = 0; i < entries.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: i is bounded by entries.length above.
     const entry = entries[i]!;
     if (entry.type !== "response_item") continue;
     const p = entry.payload;
@@ -220,6 +221,7 @@ async function extractInvocationsFromFile(
     // Find the nearest preceding user message for the trigger text.
     let triggerMessage: string | undefined;
     for (let j = i - 1; j >= 0; j--) {
+      // biome-ignore lint/style/noNonNullAssertion: j starts at i - 1 (i < entries.length from the outer loop) and only decreases while j >= 0, so it stays in bounds.
       const prev = entries[j]!;
       if (prev.type !== "response_item") continue;
       const text = userMessageText(prev.payload);
@@ -241,6 +243,7 @@ async function extractInvocationsFromFile(
     const callId = p.call_id;
     if (callId) {
       for (let j = i + 1; j < Math.min(i + 6, entries.length); j++) {
+        // biome-ignore lint/style/noNonNullAssertion: j < Math.min(i + 6, entries.length) guarantees j is in bounds.
         const next = entries[j]!;
         if (next.type !== "response_item") continue;
         const np = next.payload;

--- a/src/core/providers/scan.ts
+++ b/src/core/providers/scan.ts
@@ -13,11 +13,8 @@ export async function extractAllInvocationsForProvider(
   provider: Provider,
   opts: ExtractAllOptions = {}
 ): Promise<SkillInvocationEvent[]> {
-  if (
-    !provider.supportsScan ||
-    !provider.listSessionFiles ||
-    !provider.extractInvocationsFromFile
-  ) {
+  const { extractInvocationsFromFile } = provider;
+  if (!provider.supportsScan || !provider.listSessionFiles || !extractInvocationsFromFile) {
     throw new Error(`${provider.displayName} does not support scanning session logs.`);
   }
   const skills = await provider.listInstalledSkills();
@@ -27,7 +24,8 @@ export async function extractAllInvocationsForProvider(
     fileInfos = await provider.listSessionFiles();
   }
   if (opts.modifiedAfterMs != null) {
-    fileInfos = fileInfos.filter((f) => f.mtimeMs > opts.modifiedAfterMs!);
+    const modifiedAfterMs = opts.modifiedAfterMs;
+    fileInfos = fileInfos.filter((f) => f.mtimeMs > modifiedAfterMs);
   }
   let files = fileInfos.map((f) => f.path);
   if (opts.files) {
@@ -40,7 +38,7 @@ export async function extractAllInvocationsForProvider(
   const concurrency = Math.max(1, parseInt(process.env.CC_SCAN_CONCURRENCY ?? "8", 10) || 8);
   await mapWithLimit(files, concurrency, async (file) => {
     try {
-      const events = await provider.extractInvocationsFromFile!(file, skills, opts);
+      const events = await extractInvocationsFromFile(file, skills, opts);
       for (const ev of events) {
         if (opts.since && ev.timestamp < opts.since) continue;
         if (opts.sessionId && ev.sessionId !== opts.sessionId) continue;

--- a/src/core/providers/skill-md.ts
+++ b/src/core/providers/skill-md.ts
@@ -12,10 +12,12 @@ export function parseSkillFrontmatter(
 ): { name: string; description?: string } | null {
   const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
   if (!match) return null;
+  // biome-ignore lint/style/noNonNullAssertion: group 1 is mandatory in the pattern above, so it's always captured once `match` itself is non-null.
   const frontmatter = match[1]!;
 
   const nameMatch = /^name:\s*(.+)$/m.exec(frontmatter);
   if (!nameMatch) return null;
+  // biome-ignore lint/style/noNonNullAssertion: group 1 (`.+`) is mandatory, so it's always captured once `nameMatch` itself is non-null.
   const name = nameMatch[1]!.trim().replace(/^["']|["']$/g, "");
 
   // description may be a single line or a YAML block scalar (`>` / `|`),
@@ -23,6 +25,7 @@ export function parseSkillFrontmatter(
   const descMatch = /^description:\s*(.*)$/m.exec(frontmatter);
   let description: string | undefined;
   if (descMatch) {
+    // biome-ignore lint/style/noNonNullAssertion: group 1 is mandatory (can match an empty string, but always participates), so it's always captured here.
     const first = descMatch[1]!.trim();
     if (first === ">" || first === "|" || first === ">-" || first === "|-") {
       const afterIdx = frontmatter.indexOf(descMatch[0]) + descMatch[0].length;

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -194,6 +194,7 @@ export async function readLastEvent(
     .filter((l) => l.trim());
   for (let i = lines.length - 1; i >= 0; i--) {
     try {
+      // biome-ignore lint/style/noNonNullAssertion: i is bounded by lines.length above.
       return JSON.parse(lines[i]!) as SkillInvocationEvent;
     } catch {
       // tail may begin mid-line; keep walking backwards
@@ -406,6 +407,7 @@ export async function checkStore(dir = getStoreDir()): Promise<StoreCheckResult>
   const dupes = new Set<string>();
   const lines = raw.split("\n");
   for (let i = 0; i < lines.length; i++) {
+    // biome-ignore lint/style/noNonNullAssertion: i is bounded by lines.length above.
     const line = lines[i]!;
     if (!line.trim()) continue;
     result.totalLines++;


### PR DESCRIPTION
Closes #63.

37 sites (the issue's count of 9 was against an older codebase snapshot; the actual current count from `npx biome lint` was 37, including the new `src/core/providers/` directory added in v3.0.0). Fixed each with optional-chaining+fallback, an explicit guard, or a one-line `biome-ignore` justified by genuinely-safe prior control flow (loop bounds, mandatory regex capture groups). Pure safety refactor — no behavior change.

Verification: `npx biome lint src` reports 0 `noNonNullAssertion` warnings (1 unrelated pre-existing warning remains, untouched). typecheck/build/test all pass (282/282).

Note: I manually completed and fixed this PR — the implementing agent hit an org-wide Claude usage limit mid-task after writing all the file edits but before verifying/committing. On review I found several of its `biome-ignore` comments wrapped across two lines, which Biome doesn't recognize as suppressing the violation on the following line (only a single-line comment directly above works) — collapsed all of them to one line each, and added one missed site in `store.ts`'s `checkStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)