### PR TITLE
feat: enrich hook-captured events with scan-derived data (#223)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ src/
 5. `cc-skill-trace show` → events.jsonl を読んで **ターミナルダッシュボード**を表示
 6. `/skill-trace` (Claude Code 内) → SKILL.md の指示に従い Claude が `cc-skill-trace show --scan --terse` を実行して結果を解説
 7. `cc-skill-trace report` → events.jsonl を読んで HTML を生成しブラウザで開く
-8. `cc-skill-trace scan` → `~/.claude/projects/**/*.jsonl` を遡ってバックフィル。hook 由来イベントとは `selectNewEvents`（session+skill+args+時刻窓）で突合し二重登録を防ぐ
+8. `cc-skill-trace scan` → `~/.claude/projects/**/*.jsonl` を遡ってバックフィル。hook 由来イベントとは `selectNewEvents`（session+skill+args+時刻窓）で突合し二重登録を防ぐ。一致した場合は `enrichExistingEvents` が既存イベントの `triggerMessage`/`source` を `updateEvent` で事後補完する（#223）
 
 ### Key design decisions
 
@@ -110,9 +110,14 @@ src/
 
 ### hook-capture と triggerMessage の制限
 
-リアルタイムフック（`hook-capture`）経由で記録されたイベントには `triggerMessage` が含まれない。  
-`triggerMessage` は `cc-skill-trace scan` によるセッションログのバックフィルでのみ取得できる。  
-これは PreToolUse フックのペイロードに直前のユーザーメッセージが含まれないため。
+リアルタイムフック（`hook-capture`）経由で記録された時点のイベントには `triggerMessage` が含まれない。  
+これは PreToolUse フックのペイロードに直前のユーザーメッセージが含まれないため（恒久的な制限）。
+
+ただし `cc-skill-trace scan` を実行すると、同一の発動をセッションログから再検出し、`store.ts` の
+`enrichExistingEvents`（#223）が欠落している `triggerMessage` を**既存の hook イベントに事後的に補完**する（新しい行として二重登録はしない）。
+`source` も、hook 側が `"claude"`（不明/デフォルト）で scan 側がより確度の高い判定（例: Codex の `$SkillName` 明示呼び出し、
+Claude Code のスラッシュコマンド判定）を持つ場合に `"user"` へ upgrade される。値の追加のみを行い、既存値の上書き・劣化（`"user"` → `"claude"`）はしない。
+つまり `hook-capture` 単体では `triggerMessage` は恒久的に欠落するが、その後 `scan` を実行すれば事後的に埋まる。
 
 ### テストを追加する場所
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ cc-skill-trace completion zsh >> ~/.zshrc   # shell completion: bash | zsh | fis
 
 ### 2. Retroactive scan
 
-`~/.claude/projects/**/*.jsonl` session logs are parsed to extract past skill invocations, including the user message that preceded each one (the "trigger"). Scanned events are matched against already-captured hook events by session, skill, args and a time window — so backfilling never creates duplicates.
+`~/.claude/projects/**/*.jsonl` session logs are parsed to extract past skill invocations, including the user message that preceded each one (the "trigger"). Scanned events are matched against already-captured hook events by session, skill, args and a time window, so backfilling never creates duplicates — instead, a match enriches the existing hook-captured event in place: a missing `triggerMessage` is filled in, and `source` is upgraded from `"claude"` to `"user"` when scan finds stronger evidence of an explicit invocation (e.g. an explicit `$SkillName` mention). Fields are only ever added, never overwritten or downgraded. Run `cc-skill-trace scan` periodically (or `scan --resume`) to keep real-time-captured events enriched.
 
 ### 3. Claude Code skill (`/skill-trace`)
 

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -10,9 +10,12 @@ import {
   appendEvent,
   backupEvents,
   clearEvents,
+  enrichExistingEvents,
   readEvents,
   selectNewEvents,
+  updateEvent,
 } from "../../core/store.js";
+import type { EventEnrichment } from "../../core/store.js";
 import type { ProviderId, SkillInvocationEvent } from "../../core/types.js";
 import { getConfig } from "../context.js";
 import { buildStats, renderDashboard } from "../format.js";
@@ -61,6 +64,8 @@ export interface ScanResult {
   events: SkillInvocationEvent[];
   /** Events that were not already in the store. */
   fresh: SkillInvocationEvent[];
+  /** Existing stored events that were backfilled with richer scan data (#223). */
+  enriched: EventEnrichment[];
 }
 
 /**
@@ -83,14 +88,20 @@ export async function scanAndMerge(opts: ScanAndMergeOptions = {}): Promise<Scan
     providerId === "claude-code"
       ? await extractAllInvocations(extractOpts)
       : await extractAllInvocationsForProvider(getProvider(providerId), extractOpts);
+  const stored = await readEvents({});
   // Dedup against everything already stored — including hook-captured events,
   // which carry a random UUID rather than the scan's tool_use id, so a plain
   // id match would re-import every one of them (#182).
-  const fresh = selectNewEvents(await readEvents({}), events);
+  const fresh = selectNewEvents(stored, events);
+  // Candidates that matched an existing event (and were dropped above) may
+  // still carry a triggerMessage/source the existing hook-captured event is
+  // missing — backfill those onto the existing event in place (#223).
+  const enriched = enrichExistingEvents(stored, events);
   if (!opts.dryRun) {
     for (const ev of fresh) await appendEvent(ev);
+    for (const enrichment of enriched) await updateEvent(enrichment.id, enrichment.patch);
   }
-  return { events, fresh };
+  return { events, fresh, enriched };
 }
 
 /** Per-skill one-line summary of freshly imported events (#155). */
@@ -142,7 +153,7 @@ async function runScanOnce(opts: {
     );
   }
 
-  const { events, fresh } = await scanAndMerge({
+  const { events, fresh, enriched } = await scanAndMerge({
     since: opts.since,
     sessionId: opts.session,
     modifiedAfterMs,
@@ -175,14 +186,14 @@ async function runScanOnce(opts: {
   if (opts.dryRun) {
     console.log(
       chalk.yellow(
-        `  [dry-run] Would import ${fresh.length} new invocations (${events.length - fresh.length} already stored). Nothing written.`
+        `  [dry-run] Would import ${fresh.length} new invocations (${events.length - fresh.length} already stored), would enrich ${enriched.length} existing. Nothing written.`
       )
     );
     for (const line of freshSummary(fresh)) console.log(line);
     return;
   }
 
-  if (filtered.length === 0 && fresh.length === 0) {
+  if (filtered.length === 0 && fresh.length === 0 && enriched.length === 0) {
     console.log(chalk.yellow("  No invocations found."));
     console.log(
       chalk.gray(
@@ -195,7 +206,7 @@ async function runScanOnce(opts: {
   }
   console.log(
     chalk.green(
-      `✓  Imported ${fresh.length} new invocations (${events.length - fresh.length} already stored).`
+      `✓  Imported ${fresh.length} new invocations (${events.length - fresh.length} already stored), enriched ${enriched.length} existing.`
     )
   );
   for (const line of freshSummary(fresh)) console.log(line);

--- a/src/cli/integration.test.ts
+++ b/src/cli/integration.test.ts
@@ -124,6 +124,42 @@ describe("CLI integration", () => {
   it("scan is idempotent — re-scanning imports zero new events", () => {
     const out = run(["scan"]);
     assert.ok(out.includes("Imported 0 new invocations"));
+    assert.ok(out.includes("enriched 0 existing"));
+  });
+
+  it("scan enriches an existing hook-captured event with triggerMessage and an upgraded source instead of duplicating it (#223)", async () => {
+    // 1. Real-time hook capture: no triggerMessage available (never delivered
+    //    with PreToolUse), and source defaults to "claude" since nothing in
+    //    the payload indicates an explicit invocation.
+    const out1 = run(["hook-capture"], JSON.stringify({
+      session_id: "enrich-sess", tool_name: "Skill",
+      tool_input: { skill: "release" }, user_invoked: false,
+    }));
+    assert.equal(out1, "{}");
+    // Captured right after the hook-capture process returns so it lands well
+    // inside the (5s) hook/scan dedup window around the hook's own timestamp.
+    const preTs = new Date().toISOString();
+
+    // 2. scan reads the full session log for the SAME invocation: it has the
+    //    preceding user message (triggerMessage) and an explicit user_invoked
+    //    flag (stronger source evidence). The assistant message timestamp is
+    //    close to "now" so it falls inside the hook/scan dedup window and is
+    //    recognised as the same invocation rather than a new one.
+    await writeFile(join(projects, "enrich-sess.jsonl"), jsonl([
+      { type: "message", timestamp: preTs, sessionId: "enrich-sess", message: { role: "user", content: "/release please" } },
+      { type: "message", timestamp: preTs, sessionId: "enrich-sess", message: { role: "assistant", content: [{ type: "tool_use", id: "tu-enrich", name: "Skill", input: { skill: "release" }, user_invoked: true }] } },
+    ]));
+
+    const out2 = run(["scan"]);
+    assert.ok(out2.includes("Imported 0 new invocations"), "the matched candidate must not be stored as a second row");
+    assert.ok(out2.includes("enriched 1 existing"));
+
+    const events = JSON.parse(run(["show", "--json", "--session", "enrich-sess"]));
+    assert.equal(events.length, 1, "still exactly one event for this invocation, not a duplicate");
+    const [ev] = events;
+    assert.equal(ev.recordedVia, "hook", "the original hook-captured row is kept, patched in place");
+    assert.equal(ev.triggerMessage, "/release please");
+    assert.equal(ev.source, "user");
   });
 
   it("stats renders daily activity for the combined event set", () => {

--- a/src/core/store.test.ts
+++ b/src/core/store.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { readFile } from "node:fs/promises";
 import {
   appendEvent, readEvents, clearEvents, pruneEvents, backupEvents, pendingWriteQueueCount, selectNewEvents, DEDUP_WINDOW_MS,
-  checkStore, repairStore, updateEvent, mergeStores, readLastEvent,
+  checkStore, repairStore, updateEvent, mergeStores, readLastEvent, enrichExistingEvents,
 } from "./store.js";
 import type { SkillInvocationEvent } from "./types.js";
 
@@ -316,6 +316,102 @@ describe("store", () => {
       // Candidates are only compared against `existing`, never each other, so both survive.
       const fresh = selectNewEvents([], [first, second]);
       assert.deepEqual(fresh.map((e) => e.id).sort(), ["toolu_1", "toolu_2"]);
+    });
+  });
+
+  describe("enrichExistingEvents (#223)", () => {
+    // A candidate dropped by selectNewEvents (matches an existing event by id
+    // or sameInvocation) isn't necessarily redundant — scan can carry a
+    // triggerMessage/source the hook-captured event was never able to record.
+    const hookEvent = makeEvent({
+      id: "uuid-random-1234",
+      timestamp: "2026-01-01T00:00:01.000Z",
+      sessionId: "s1",
+      skillName: "commit",
+      source: "claude",
+    });
+    const scanOfSameInvocation = makeEvent({
+      id: "toolu_abc123",
+      timestamp: "2026-01-01T00:00:02.500Z",
+      sessionId: "s1",
+      skillName: "commit",
+      source: "user",
+      triggerMessage: "please commit this",
+    });
+
+    it("backfills triggerMessage onto the existing event when it has none", () => {
+      const enrichments = enrichExistingEvents(
+        [{ ...hookEvent, source: "user" }],
+        [{ ...scanOfSameInvocation, source: "user" }]
+      );
+      assert.deepEqual(enrichments, [
+        { id: "uuid-random-1234", patch: { triggerMessage: "please commit this" } },
+      ]);
+    });
+
+    it("upgrades source from \"claude\" to \"user\" when scan found stronger evidence", () => {
+      const enrichments = enrichExistingEvents(
+        [{ ...hookEvent, triggerMessage: "already have one" }],
+        [{ ...scanOfSameInvocation, triggerMessage: "already have one" }]
+      );
+      assert.deepEqual(enrichments, [{ id: "uuid-random-1234", patch: { source: "user" } }]);
+    });
+
+    it("backfills both triggerMessage and source in one patch when both are missing", () => {
+      const enrichments = enrichExistingEvents([hookEvent], [scanOfSameInvocation]);
+      assert.deepEqual(enrichments, [
+        {
+          id: "uuid-random-1234",
+          patch: { triggerMessage: "please commit this", source: "user" },
+        },
+      ]);
+    });
+
+    it("never downgrades source from \"user\" to \"claude\"", () => {
+      const existingUser = { ...hookEvent, source: "user" as const, triggerMessage: "keep me" };
+      const candidateClaude = { ...scanOfSameInvocation, source: "claude" as const };
+      const enrichments = enrichExistingEvents([existingUser], [candidateClaude]);
+      assert.deepEqual(enrichments, []);
+    });
+
+    it("never overwrites an existing triggerMessage with the candidate's", () => {
+      const existingWithMessage = { ...hookEvent, triggerMessage: "original message" };
+      const enrichments = enrichExistingEvents([existingWithMessage], [scanOfSameInvocation]);
+      // source is still upgraded, but triggerMessage is left untouched.
+      assert.deepEqual(enrichments, [{ id: "uuid-random-1234", patch: { source: "user" } }]);
+    });
+
+    it("produces no enrichment when nothing new is available", () => {
+      const alreadyRich = { ...hookEvent, source: "user" as const, triggerMessage: "already have one" };
+      const enrichments = enrichExistingEvents([alreadyRich], [scanOfSameInvocation]);
+      assert.deepEqual(enrichments, []);
+    });
+
+    it("produces no enrichment when the candidate does not match any existing event", () => {
+      const otherSession = { ...scanOfSameInvocation, sessionId: "s2" };
+      const enrichments = enrichExistingEvents([hookEvent], [otherSession]);
+      assert.deepEqual(enrichments, []);
+    });
+
+    it("leaves every field other than triggerMessage/source untouched", () => {
+      const enrichments = enrichExistingEvents([hookEvent], [scanOfSameInvocation]);
+      assert.deepEqual(Object.keys(enrichments[0]!.patch).sort(), ["source", "triggerMessage"]);
+    });
+
+    it("enriches the existing hook-captured event in the store via updateEvent, without creating a duplicate (#223)", async () => {
+      const enrichDir = dir + "-enrich";
+      await appendEvent(hookEvent, enrichDir);
+      const stored = await readEvents(enrichDir);
+      const enrichments = enrichExistingEvents(stored, [scanOfSameInvocation]);
+      assert.equal(enrichments.length, 1);
+      for (const e of enrichments) await updateEvent(e.id, e.patch, enrichDir);
+
+      const after = await readEvents(enrichDir);
+      assert.equal(after.length, 1, "the scan candidate must not be appended as a second row");
+      assert.equal(after[0]!.id, hookEvent.id, "the original hook-captured id is preserved");
+      assert.equal(after[0]!.recordedVia, hookEvent.recordedVia);
+      assert.equal(after[0]!.triggerMessage, "please commit this");
+      assert.equal(after[0]!.source, "user");
     });
   });
 

--- a/src/core/store.ts
+++ b/src/core/store.ts
@@ -246,6 +246,64 @@ export function selectNewEvents(
   return fresh;
 }
 
+// ─── Enriching hook-captured events from scan (#223) ─────────────────────────
+// A candidate dropped by `selectNewEvents` (because it matches an existing
+// event by id or by `sameInvocation`) isn't necessarily redundant: scan reads
+// the full session log, so it can carry a `triggerMessage` the hook-captured
+// event was never able to record (the PreToolUse payload has no preceding
+// message text), and — for providers like Codex — a more confident `source`
+// determination (e.g. an explicit `$SkillName` mention) than the hook could
+// make on its own. `enrichExistingEvents` finds those matches and reports
+// only the fields that should be backfilled onto the *existing* stored event,
+// leaving every other field (id, timestamp, sessionId, skillArgs, provider,
+// recordedVia, outcome, durationMs, tags, ...) untouched.
+
+/** A backfill patch for one already-stored event, computed by {@link enrichExistingEvents}. */
+export interface EventEnrichment {
+  /** ID of the existing stored event to patch (via {@link updateEvent}). */
+  id: string;
+  /** Only ever contains `triggerMessage` and/or `source` — additive fields only. */
+  patch: Partial<Pick<SkillInvocationEvent, "triggerMessage" | "source">>;
+}
+
+/**
+ * From freshly scanned `candidates`, compute enrichment patches for matching
+ * `existing` events (#223). A candidate "matches" an existing event the same
+ * way `selectNewEvents` decides to drop it: same id, or {@link sameInvocation}.
+ *
+ * Only two fields are ever backfilled, and only when they add information:
+ *  - `triggerMessage`: copied over when the existing event is missing one and
+ *    the candidate has one.
+ *  - `source`: upgraded from `"claude"` to `"user"` when the candidate found
+ *    stronger evidence of an explicit invocation. Never downgraded the other
+ *    way — enrichment only ever adds information, never removes it.
+ *
+ * Existing events with nothing to add are omitted from the result, so callers
+ * can skip a no-op `updateEvent` write.
+ */
+export function enrichExistingEvents(
+  existing: SkillInvocationEvent[],
+  candidates: SkillInvocationEvent[]
+): EventEnrichment[] {
+  const enrichments: EventEnrichment[] = [];
+  for (const candidate of candidates) {
+    const match = existing.find((e) => e.id === candidate.id || sameInvocation(e, candidate));
+    if (!match) continue;
+
+    const patch: EventEnrichment["patch"] = {};
+    if (match.triggerMessage == null && candidate.triggerMessage != null) {
+      patch.triggerMessage = candidate.triggerMessage;
+    }
+    if (match.source === "claude" && candidate.source === "user") {
+      patch.source = "user";
+    }
+    if (Object.keys(patch).length > 0) {
+      enrichments.push({ id: match.id, patch });
+    }
+  }
+  return enrichments;
+}
+
 /** Delete all events (truncates the file). */
 export function clearEvents(dir = getStoreDir()): Promise<void> {
   return enqueueWrite(dir, async () => {


### PR DESCRIPTION
Closes #223.

`hook-capture` (real-time) can never record `triggerMessage` — the PreToolUse payload carries no preceding message text (permanent limitation). `scan` CAN recover it by reading the full session log, including for invocations already captured live by the hook — but previously that richer data was discarded: `selectNewEvents` just dropped any scanned candidate matching an existing stored event.

Now `store.ts` exposes a pure `enrichExistingEvents(existing, candidates)` that computes backfill patches (only ever `triggerMessage`/`source`, additive only — never overwrites or downgrades), and `scanAndMerge` applies them via the existing `updateEvent` path, reporting the count in `scan`'s output.

Verification: typecheck/lint/format/build all pass. Full test suite 292/292 (10 new tests: 8 unit tests on `enrichExistingEvents` covering upgrade/no-downgrade/no-overwrite/no-match cases, plus a real end-to-end CLI integration test — hook-capture, then a matching session log, then `scan`, asserting the event count stays at 1 and gets patched in place, not duplicated).

Note: I manually completed, rebased onto latest main, and verified this PR — the implementing agent hit an org-wide Claude usage limit mid-task after writing the implementation but before verifying/committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)