### PR TITLE
feat: scan --all-providers backfills every scan-capable provider (#227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ cc-skill-trace install --provider codex
 # also requires [features].codex_hooks = true in ~/.codex/config.toml (not auto-edited)
 cc-skill-trace scan --provider codex
 
+# Scan every provider that supports retroactive scanning (currently claude-code + codex)
+# in one pass — copilot is skipped, not errored on, since it has no session logs (#227)
+cc-skill-trace scan --all-providers
+
 # GitHub Copilot CLI (hook-capture only — no retroactive scan)
 cc-skill-trace install --provider copilot
 
@@ -214,6 +218,7 @@ cc-skill-trace scan --resume             # only files touched since the last sca
 cc-skill-trace scan --dry-run            # preview counts without writing
 cc-skill-trace scan --watch              # keep importing new events as sessions grow
 cc-skill-trace scan --clear              # back up, clear, then rescan from scratch
+cc-skill-trace scan --all-providers      # scan every scan-capable provider in one pass (#227)
 ```
 
 ### Data Management

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 import { getStoreDir, loadState, saveState } from "../../core/config.js";
 import { extractAllInvocations, listSessionFiles, newestMtimeMs } from "../../core/parser.js";
 import type { ExtractAllOptions } from "../../core/parser.js";
-import { getProvider } from "../../core/providers/index.js";
+import { ALL_PROVIDER_IDS, getProvider } from "../../core/providers/index.js";
 import { extractAllInvocationsForProvider } from "../../core/providers/scan.js";
 import {
   appendEvent,
@@ -17,7 +17,7 @@ import type { ProviderId, SkillInvocationEvent } from "../../core/types.js";
 import { getConfig } from "../context.js";
 import { buildStats, renderDashboard } from "../format.js";
 import { parseDateOpt, parseProviderOpt, validateDateRange } from "../options.js";
-import { vlog } from "../ui.js";
+import { fail, vlog } from "../ui.js";
 
 /** Render scan progress with percent, ETA and current file (#140). */
 function makeProgressRenderer(): (done: number, total: number, file?: string) => void {
@@ -103,6 +103,50 @@ function freshSummary(fresh: SkillInvocationEvent[]): string[] {
   return lines;
 }
 
+/**
+ * Back up the store then clear it (scan --clear, #180). Shared by the
+ * single-provider and --all-providers scan paths so a multi-provider run
+ * only clears once, up front, rather than per provider (#227).
+ */
+async function clearStoreWithBackup(): Promise<void> {
+  const { backupPath, rotatedTo } = await backupEvents();
+  if (backupPath) {
+    if (rotatedTo) console.log(chalk.gray(`  Previous backup moved to ${rotatedTo}`));
+    console.log(chalk.gray(`  Backup saved to ${backupPath}`));
+    console.log(
+      chalk.gray(`  To restore: cp ${backupPath} ${join(getStoreDir(), "events.jsonl")}`)
+    );
+  }
+  await clearEvents();
+  console.log(chalk.gray("  Cleared."));
+}
+
+/** Resolve the resume cursor (last-scanned mtime) for one provider (#165, #227). */
+async function resumeCursorFor(providerId: ProviderId): Promise<number | undefined> {
+  const state = await loadState();
+  return providerId === "claude-code"
+    ? state.lastScanMtimeMs
+    : state.lastScanMtimeMsByProvider?.[providerId];
+}
+
+/** Persist the resume cursor for one provider after a scan that wrote to the store (#165, #227). */
+async function saveResumeCursor(providerId: ProviderId): Promise<void> {
+  if (providerId === "claude-code") {
+    const files = await listSessionFiles();
+    await saveState({ lastScanMtimeMs: newestMtimeMs(files) });
+    return;
+  }
+  const provider = getProvider(providerId);
+  const files = (await provider.listSessionFiles?.()) ?? [];
+  const state = await loadState();
+  await saveState({
+    lastScanMtimeMsByProvider: {
+      ...state.lastScanMtimeMsByProvider,
+      [providerId]: newestMtimeMs(files),
+    },
+  });
+}
+
 async function runScanOnce(opts: {
   since?: string;
   before?: string;
@@ -117,26 +161,12 @@ async function runScanOnce(opts: {
   validateDateRange(opts.since, opts.before);
   const providerId = opts.provider ?? "claude-code";
   if (opts.clear && !opts.dryRun) {
-    // Back up before clearing so a mid-scan failure can't destroy history (#180).
-    const { backupPath, rotatedTo } = await backupEvents();
-    if (backupPath) {
-      if (rotatedTo) console.log(chalk.gray(`  Previous backup moved to ${rotatedTo}`));
-      console.log(chalk.gray(`  Backup saved to ${backupPath}`));
-      console.log(
-        chalk.gray(`  To restore: cp ${backupPath} ${join(getStoreDir(), "events.jsonl")}`)
-      );
-    }
-    await clearEvents();
-    console.log(chalk.gray("  Cleared."));
+    await clearStoreWithBackup();
   }
 
   let modifiedAfterMs: number | undefined;
   if (opts.resume) {
-    const state = await loadState();
-    modifiedAfterMs =
-      providerId === "claude-code"
-        ? state.lastScanMtimeMs
-        : state.lastScanMtimeMsByProvider?.[providerId];
+    modifiedAfterMs = await resumeCursorFor(providerId);
     vlog(
       `resume: only files modified after ${modifiedAfterMs ? new Date(modifiedAfterMs).toISOString() : "(never scanned)"}`
     );
@@ -152,20 +182,7 @@ async function runScanOnce(opts: {
   });
 
   if (!opts.dryRun) {
-    if (providerId === "claude-code") {
-      const files = await listSessionFiles();
-      await saveState({ lastScanMtimeMs: newestMtimeMs(files) });
-    } else {
-      const provider = getProvider(providerId);
-      const files = (await provider.listSessionFiles?.()) ?? [];
-      const state = await loadState();
-      await saveState({
-        lastScanMtimeMsByProvider: {
-          ...state.lastScanMtimeMsByProvider,
-          [providerId]: newestMtimeMs(files),
-        },
-      });
-    }
+    await saveResumeCursor(providerId);
   }
 
   let filtered = events;
@@ -200,6 +217,63 @@ async function runScanOnce(opts: {
   );
   for (const line of freshSummary(fresh)) console.log(line);
   console.log(`\n${renderDashboard(filtered)}`);
+}
+
+/**
+ * Scan every provider that supports retroactive session-log scanning, one
+ * after another, printing a compact per-provider summary line rather than a
+ * full dashboard per provider (scan --all-providers, #227). Providers without
+ * scan support (currently copilot) are silently skipped — not an error.
+ */
+async function runScanAllProviders(opts: {
+  since?: string;
+  session?: string;
+  clear?: boolean;
+  dryRun?: boolean;
+  resume?: boolean;
+  capture?: boolean;
+}): Promise<void> {
+  if (opts.clear && !opts.dryRun) {
+    await clearStoreWithBackup();
+  }
+
+  const scannableIds = ALL_PROVIDER_IDS.filter((id) => getProvider(id).supportsScan);
+
+  for (const providerId of scannableIds) {
+    let modifiedAfterMs: number | undefined;
+    if (opts.resume) {
+      modifiedAfterMs = await resumeCursorFor(providerId);
+      vlog(
+        `resume (${providerId}): only files modified after ${modifiedAfterMs ? new Date(modifiedAfterMs).toISOString() : "(never scanned)"}`
+      );
+    }
+
+    const { events, fresh } = await scanAndMerge({
+      since: opts.since,
+      sessionId: opts.session,
+      modifiedAfterMs,
+      dryRun: opts.dryRun,
+      noCapture: opts.capture === false,
+      provider: providerId,
+    });
+
+    if (!opts.dryRun) {
+      await saveResumeCursor(providerId);
+    }
+
+    const label = chalk.bold(`  ${providerId}:`);
+    if (opts.dryRun) {
+      console.log(
+        `${label} ${chalk.yellow(`[dry-run] Would import ${fresh.length} new invocations (${events.length - fresh.length} already stored).`)}`
+      );
+    } else if (events.length === 0 && fresh.length === 0) {
+      console.log(`${label} ${chalk.yellow("No invocations found.")}`);
+    } else {
+      console.log(
+        `${label} ${chalk.green(`Imported ${fresh.length} new invocations (${events.length - fresh.length} already stored).`)}`
+      );
+    }
+  }
 }
 
 /** Poll session files and import new events as they appear (#128). */
@@ -266,7 +340,24 @@ export function registerScanCommand(program: Command): void {
       "Agent CLI to scan: claude-code (default), codex — copilot has no session logs to scan (#v3-multi-provider)",
       parseProviderOpt
     )
+    .option(
+      "--all-providers",
+      "Scan every provider that supports retroactive log scanning (currently claude-code + codex; copilot is skipped) — mutually exclusive with --provider (#227)"
+    )
     .action(async (opts) => {
+      if (opts.allProviders && opts.provider) {
+        fail("--all-providers and --provider are mutually exclusive — drop one.");
+      }
+      if (opts.allProviders && opts.watch) {
+        fail(
+          "--all-providers does not support --watch. Run scan --watch --provider <id> for one provider at a time."
+        );
+      }
+      if (opts.allProviders) {
+        await runScanAllProviders(opts);
+        return;
+      }
+
       const providerId: ProviderId = opts.provider ?? "claude-code";
       if (providerId !== "claude-code" && !getProvider(providerId).supportsScan) {
         console.log(

--- a/src/cli/integration.test.ts
+++ b/src/cli/integration.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
-import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile, readFile, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -335,5 +335,174 @@ describe("multi-provider install/hook-capture (#v3-multi-provider)", () => {
     assert.ok(out.includes("removed from"));
     const settings = JSON.parse(await readFile(join(home, ".codex", "hooks.json"), "utf-8"));
     assert.equal((settings.hooks.PreToolUse ?? []).length, 0);
+  });
+});
+
+describe("scan --all-providers (#227)", () => {
+  let home: string;
+  let store: string;
+  let projects: string;
+  let env: NodeJS.ProcessEnv;
+  const oldCodexMtime = new Date("2020-01-01T00:00:00.000Z");
+
+  before(async () => {
+    const root = await mkdtemp(join(tmpdir(), "cc-skill-trace-scan-all-test-"));
+    home = join(root, "home");
+    store = join(root, "store");
+    projects = join(root, "projects", "fake-project");
+    await mkdir(home, { recursive: true });
+    await mkdir(store, { recursive: true });
+    await mkdir(projects, { recursive: true });
+    env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      CC_STORE_DIR: store,
+      CC_PROJECTS_DIR: join(root, "projects"),
+      NO_COLOR: "1",
+    };
+
+    // Claude Code fixture: one Skill tool_use in a fabricated session log.
+    await writeFile(
+      join(projects, "sess1.jsonl"),
+      jsonl([
+        {
+          type: "message",
+          timestamp: "2026-01-05T09:00:00.000Z",
+          sessionId: "cc-sess1",
+          message: { role: "user", content: "help me commit" },
+        },
+        {
+          type: "message",
+          timestamp: "2026-01-05T09:00:01.000Z",
+          sessionId: "cc-sess1",
+          message: {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "tu-1", name: "Skill", input: { skill: "commit" } }],
+          },
+        },
+      ])
+    );
+
+    // Codex fixture: an installed skill + a rollout file referencing its SKILL.md path.
+    // The rollout file's mtime is pinned to the past so a later test can add a *new*
+    // rollout file and prove --resume only picks up files newer than the saved cursor.
+    const codexSkillDir = join(home, ".codex", "skills", "github");
+    await mkdir(codexSkillDir, { recursive: true });
+    const codexSkillPath = join(codexSkillDir, "SKILL.md");
+    await writeFile(codexSkillPath, "---\nname: github\ndescription: Work with GitHub\n---\n");
+
+    const codexSessDir = join(home, ".codex", "sessions", "2020", "01", "01");
+    await mkdir(codexSessDir, { recursive: true });
+    const codexRolloutPath = join(codexSessDir, "rollout-2020-01-01T00-00-00-uuid1.jsonl");
+    await writeFile(
+      codexRolloutPath,
+      jsonl([
+        { type: "session_meta", payload: { id: "codex-sess1", cwd: "/repo" } },
+        {
+          type: "response_item",
+          timestamp: "2020-01-01T00:00:36.000Z",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            call_id: "call_1",
+            arguments: JSON.stringify({ cmd: `sed -n '1,220p' ${codexSkillPath}` }),
+          },
+        },
+      ])
+    );
+    await utimes(codexRolloutPath, oldCodexMtime, oldCodexMtime);
+
+    // Copilot fixture: a skill is installed, but copilot has no scannable session-log
+    // format — this proves --all-providers skips it silently rather than erroring.
+    const copilotSkillDir = join(home, ".copilot", "skills", "pdf");
+    await mkdir(copilotSkillDir, { recursive: true });
+    await writeFile(join(copilotSkillDir, "SKILL.md"), "---\nname: pdf\ndescription: PDF tools\n---\n");
+  });
+
+  after(async () => {
+    await rm(join(home, ".."), { recursive: true, force: true });
+  });
+
+  function run(args: string[], input?: string): string {
+    return execFileSync("node", ["--import", "tsx/esm", CLI_ENTRY, ...args], {
+      env, encoding: "utf-8", input: input ?? "", timeout: 15_000,
+    });
+  }
+
+  it("rejects --all-providers combined with --provider", () => {
+    assert.throws(() => run(["scan", "--all-providers", "--provider", "codex"]));
+  });
+
+  it("rejects --all-providers combined with --watch", () => {
+    assert.throws(() => run(["scan", "--all-providers", "--watch"]));
+  });
+
+  it("--help lists the --all-providers flag", () => {
+    const out = run(["scan", "--help"]);
+    assert.ok(out.includes("--all-providers"));
+  });
+
+  it("scans every scan-capable provider and prints a per-provider summary line, skipping copilot", async () => {
+    const out = run(["scan", "--all-providers"]);
+    assert.ok(out.includes("claude-code: Imported 1 new invocations"), out);
+    assert.ok(out.includes("codex: Imported 1 new invocations"), out);
+    assert.ok(!out.includes("copilot"), "copilot has no session logs to scan and must be skipped silently");
+
+    const raw = await readFile(join(store, "events.jsonl"), "utf-8");
+    const events = raw
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    // A missing `provider` field on a stored event always means claude-code (#v3-multi-provider).
+    const providers = events.map((e) => e.provider ?? "claude-code").sort();
+    assert.deepEqual(providers, ["claude-code", "codex"]);
+  });
+
+  it("is idempotent — re-running --all-providers imports zero new events for every provider", () => {
+    const out = run(["scan", "--all-providers"]);
+    assert.ok(out.includes("claude-code: Imported 0 new invocations"), out);
+    assert.ok(out.includes("codex: Imported 0 new invocations"), out);
+  });
+
+  it("--resume tracks an independent cursor per provider", async () => {
+    // Add a *new* codex rollout file only — claude-code gets nothing new — then
+    // verify --resume correctly attributes the new invocation to codex alone,
+    // proving lastScanMtimeMs (claude-code) and lastScanMtimeMsByProvider.codex
+    // are read/written independently in the --all-providers loop.
+    const skillDir = join(home, ".codex", "skills", "github");
+    const skillPath = join(skillDir, "SKILL.md");
+    const codexSessDir = join(home, ".codex", "sessions", "2026", "01", "05");
+    await mkdir(codexSessDir, { recursive: true });
+    await writeFile(
+      join(codexSessDir, "rollout-2026-01-05T00-00-00-uuid2.jsonl"),
+      jsonl([
+        { type: "session_meta", payload: { id: "codex-sess2", cwd: "/repo" } },
+        {
+          type: "response_item",
+          timestamp: "2026-01-05T00:00:36.000Z",
+          payload: {
+            type: "function_call",
+            name: "exec_command",
+            call_id: "call_2",
+            arguments: JSON.stringify({ cmd: `sed -n '1,220p' ${skillPath}` }),
+          },
+        },
+      ])
+    );
+
+    const out = run(["scan", "--all-providers", "--resume"]);
+    // claude-code has no file newer than its cursor, so nothing is scanned at all
+    // (not just zero *new* events) — matches runScanOnce's "No invocations found" branch.
+    assert.ok(out.includes("claude-code: No invocations found."), out);
+    assert.ok(out.includes("codex: Imported 1 new invocations"), out);
+
+    const state = JSON.parse(await readFile(join(store, "state.json"), "utf-8"));
+    assert.ok(typeof state.lastScanMtimeMs === "number");
+    assert.ok(typeof state.lastScanMtimeMsByProvider?.codex === "number");
+    assert.ok(
+      state.lastScanMtimeMsByProvider.codex > oldCodexMtime.getTime(),
+      "codex cursor must advance past the pinned old rollout file's mtime"
+    );
   });
 });


### PR DESCRIPTION
Closes #227.

`--provider <id>` scans one provider at a time — scanning both Claude Code and Codex needed two separate commands. `--all-providers` scans every provider with `supportsScan === true` (derived from `ALL_PROVIDER_IDS`, not hardcoded) in one pass with a per-provider summary line. Providers without scan support (copilot) are silently skipped.

```bash
cc-skill-trace scan --all-providers
#  claude-code: Imported 3 new invocations (12 already stored).
#  codex:       Imported 1 new invocation (0 already stored).
```

`--all-providers`+`--provider` and `--all-providers`+`--watch` are both rejected with clear errors. `--resume` correctly tracks each provider's own cursor independently — covered by a dedicated integration test that pins one provider's fixture file to an old mtime and confirms only the other provider's new file gets picked up.

Verification: typecheck/lint/format/build pass. Full suite 288/288 (6 new integration tests).

**Heads up on merge order**: this PR and #238 (noNonNullAssertion fixes) and #240 (enrich hook events) all touch `src/cli/commands/scan.ts`. Each is independently clean against current `main`, but merging more than one will need a rebase to resolve the resulting conflict in that file — recommend reviewing/merging one at a time rather than all at once.

Note: I manually completed, rebased onto latest main, and verified this PR — the implementing agent hit an org-wide Claude usage limit mid-task after writing the implementation but before verifying/committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)